### PR TITLE
Stabilize Paper menu/input flow and move build toolchain to Java 25

### DIFF
--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
@@ -2,31 +2,23 @@ package me.combimagnetron.sunscreen.neo;
 
 import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
 import me.combimagnetron.passport.util.data.Identifier;
-import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.SunscreenLibrary;
 import me.combimagnetron.sunscreen.neo.element.ElementLike;
 import me.combimagnetron.sunscreen.neo.element.GenericInteractableModernElement;
 import me.combimagnetron.sunscreen.neo.input.InputHandler;
-import me.combimagnetron.sunscreen.neo.input.context.InputContext;
-import me.combimagnetron.sunscreen.neo.input.context.MouseInputContext;
-import me.combimagnetron.sunscreen.neo.input.context.ScrollInputContext;
 import me.combimagnetron.sunscreen.neo.loader.MenuComponent;
 import me.combimagnetron.sunscreen.neo.loader.MenuComponentLoaderContext;
 import me.combimagnetron.sunscreen.neo.protocol.PlatformProtocolIntermediate;
-import me.combimagnetron.sunscreen.neo.protocol.type.EntityReference;
 import me.combimagnetron.sunscreen.neo.protocol.type.Location;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderPipeline;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderThreadPoolHandler;
 import me.combimagnetron.sunscreen.neo.session.Session;
 import me.combimagnetron.sunscreen.user.SunscreenUser;
 import me.combimagnetron.sunscreen.util.IdentifierHolder;
-import me.combimagnetron.sunscreen.util.Scheduler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class ActiveMenu implements IdentifierHolder {
@@ -61,10 +53,10 @@ public class ActiveMenu implements IdentifierHolder {
 
     private void loadComponents() {
         MenuComponentLoaderContext context = new MenuComponentLoaderContext(null, null, null, menuRoot);
-        menuRoot.components().parallelStream().forEach(component -> {
+        for (final MenuComponent<?> component : menuRoot.components()) {
             MenuComponent<?> loaded = component.loader().load(context);
             loadedComponents.put((Class<MenuComponent<?>>) component.getClass(), loaded);
-        });
+        }
     }
 
     public @NotNull MenuRoot root() {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
@@ -30,7 +30,7 @@ public class InputHandler {
         C mutatedInput = function.apply(currentInput);
         inputContextMap.put(type, mutatedInput);
         Event event = mutatedInput.constructEvent(user);
-        Dispatcher.dispatcher().post(mutatedInput.eventType(), event);
+        Dispatcher.dispatcher().post(currentInput.eventType(), event);
         return mutatedInput;
     }
 

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
@@ -1,7 +1,5 @@
 package me.combimagnetron.sunscreen.neo.input;
 
-import com.google.common.collect.ClassToInstanceMap;
-import com.google.common.collect.MutableClassToInstanceMap;
 import me.combimagnetron.passport.event.Dispatcher;
 import me.combimagnetron.passport.event.Event;
 import me.combimagnetron.passport.util.math.Vec2i;
@@ -31,8 +29,8 @@ public class InputHandler {
         C currentInput = (C) inputContextMap.get(type);
         C mutatedInput = function.apply(currentInput);
         inputContextMap.put(type, mutatedInput);
-        Event event = currentInput.constructEvent(user);
-        Dispatcher.dispatcher().post(currentInput.eventType(), event);
+        Event event = mutatedInput.constructEvent(user);
+        Dispatcher.dispatcher().post(mutatedInput.eventType(), event);
         return mutatedInput;
     }
 

--- a/build-system/build.gradle.kts
+++ b/build-system/build.gradle.kts
@@ -24,5 +24,5 @@ tasks.test {
     useJUnitPlatform()
 }
 kotlin {
-    jvmToolchain(24)
+    jvmToolchain(25)
 }

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
@@ -57,6 +57,7 @@ public class ProtocolListener implements PacketListener {
     }
 
     private void handleMapData(PacketSendEvent packetSendEvent, SunscreenUser<?> user) {
+        if (inMenu(user)) return;
         WrapperPlayServerMapData data = new WrapperPlayServerMapData(packetSendEvent);
         if (data.getMapId() > 0) return;
         packetSendEvent.setCancelled(true);

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
@@ -10,24 +10,14 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPl
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerRotation;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerMapData;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTimeUpdate;
-import me.combimagnetron.passport.event.Dispatcher;
-import me.combimagnetron.passport.util.data.Identifier;
-import me.combimagnetron.passport.util.math.Vec2f;
-import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.SunscreenLibrary;
-import me.combimagnetron.sunscreen.neo.ActiveMenu;
-import me.combimagnetron.sunscreen.neo.element.ElementLike;
-import me.combimagnetron.sunscreen.neo.event.UserMoveStateChangeEvent;
 import me.combimagnetron.sunscreen.neo.input.InputHandler;
 import me.combimagnetron.sunscreen.neo.input.context.MouseInputContext;
-import me.combimagnetron.sunscreen.neo.property.Position;
-import me.combimagnetron.sunscreen.neo.render.Viewport;
 import me.combimagnetron.sunscreen.neo.session.Session;
 import me.combimagnetron.sunscreen.user.SunscreenUser;
 import me.combimagnetron.sunscreen.util.Scheduler;
 import me.combimagnetron.sunscreen.util.helper.RotationHelper;
 import net.kyori.adventure.audience.Audience;
-import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -67,7 +57,6 @@ public class ProtocolListener implements PacketListener {
     }
 
     private void handleMapData(PacketSendEvent packetSendEvent, SunscreenUser<?> user) {
-        if (inMenu(user)) return;
         WrapperPlayServerMapData data = new WrapperPlayServerMapData(packetSendEvent);
         if (data.getMapId() > 0) return;
         packetSendEvent.setCancelled(true);
@@ -78,11 +67,9 @@ public class ProtocolListener implements PacketListener {
         final Session session = user.session();
         if (session == null) return;
         final InputHandler inputHandler = session.menu().inputHandler();
-        MouseInputContext mutatedContext = inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(true), user);
-        Dispatcher.dispatcher().post(new UserMoveStateChangeEvent(user, mutatedContext));
+        inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(true), user);
         Scheduler.delayTick(() -> {
-            MouseInputContext secondMutatedContext = inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(false), user);
-            Dispatcher.dispatcher().post(new UserMoveStateChangeEvent(user, secondMutatedContext));
+            inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(false), user);
         });
     }
 
@@ -109,8 +96,7 @@ public class ProtocolListener implements PacketListener {
         final InputHandler inputHandler = session.menu().inputHandler();
         float yaw = wrapperPlayClientPlayerRotation.getYaw();
         float pitch = wrapperPlayClientPlayerRotation.getPitch();
-        MouseInputContext mutatedContext = inputHandler.peek(MouseInputContext.class, old -> old.withPosition(RotationHelper.convert(yaw, pitch, user.screenInfo())), user);
-        Dispatcher.dispatcher().post(new UserMoveStateChangeEvent(user, mutatedContext));
+        inputHandler.peek(MouseInputContext.class, old -> old.withPosition(RotationHelper.convert(yaw, pitch, user.screenInfo())), user);
     }
 
     static boolean inMenu(@NotNull SunscreenUser<?> user) {

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/SpigotPlatformProtocolIntermediate.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/SpigotPlatformProtocolIntermediate.java
@@ -151,10 +151,13 @@ public class SpigotPlatformProtocolIntermediate implements PlatformProtocolInter
         WrapperPlayServerCamera camera = new WrapperPlayServerCamera(user.entityId());
         WrapperPlayServerChangeGameState gameState = new WrapperPlayServerChangeGameState(WrapperPlayServerChangeGameState.Reason.CHANGE_GAME_MODE, user.gameMode());
         WrapperPlayServerTimeUpdate timeUpdate = new WrapperPlayServerTimeUpdate(player.getWorld().getGameTime(), player.getPlayerTime());
-        int[] ids = entities.columnKeySet().stream().mapToInt(Integer::intValue).toArray();
-        user.connection().send(new WrapperPlayServerDestroyEntities(ids));
+        final Map<Integer, Object> trackedEntities = entities.row(user.uniqueIdentifier());
+        final int[] ids = trackedEntities.keySet().stream().mapToInt(Integer::intValue).toArray();
+        if (ids.length > 0) {
+            user.connection().send(new WrapperPlayServerDestroyEntities(ids));
+        }
         user.connection().send(new WrapperPlayServerDestroyEntities(-10_000));
-        entities.row(user.uniqueIdentifier()).clear();
+        trackedEntities.clear();
         user.connection().send(new WrapperPlayServerPlayerPositionAndLook(user.position().x(), user.position().y(), user.position().z(), (float) initialRotation.x(), (float) initialRotation.y(), (byte)0, 0, false));
         user.connection().send(timeUpdate);
         user.connection().send(gameState);

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
@@ -11,13 +11,12 @@ import me.combimagnetron.passport.internal.entity.Entity;
 import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
 import me.combimagnetron.passport.internal.network.Connection;
 import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.neo.ActiveMenu;
 import me.combimagnetron.sunscreen.neo.MenuTemplate;
 import me.combimagnetron.sunscreen.neo.protocol.type.Location;
 import me.combimagnetron.sunscreen.neo.render.ScreenInfo;
 import me.combimagnetron.sunscreen.neo.render.Viewport;
 import me.combimagnetron.sunscreen.neo.session.Session;
-import me.combimagnetron.passport.util.data.Pair;
-import me.combimagnetron.passport.util.math.Vec2d;
 import me.combimagnetron.passport.util.math.Vec2i;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -119,12 +118,17 @@ public class UserImpl implements SunscreenUser<Player> {
 
     @Override
     public @NotNull Session open(@NotNull MenuTemplate template) {
-        /*OpenedMenu.FloatImpl menu = new OpenedMenu.Float(this, template);
-        SunscreenLibrary.library().menuTicker().start(menu);
-        menu.open(this);
-        Session session = Session.session(menu, this);
-        return SunscreenLibrary.library().sessionHandler().session(session);*/
-        return null;
+        final Session current = this.session();
+        if (current != null) {
+            current.menu().close();
+        }
+
+        new ActiveMenu(template, this, template.identifier());
+        final Session created = this.session();
+        if (created == null) {
+            throw new IllegalStateException("Failed to create menu session for " + this.uniqueIdentifier());
+        }
+        return created;
     }
 
     @Override

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserManager.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserManager.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.*;
 
 public class UserManager implements Listener, UserHandler<Player, SunscreenUser<Player>> {
-    private final Map<UUID, SunscreenUser<Player>> userMap = new WeakHashMap<>();
+    private final Map<UUID, SunscreenUser<Player>> userMap = new HashMap<>();
 
     public UserManager(SunscreenPlugin library) {
         Bukkit.getServer().getPluginManager().registerEvents(this, library);
@@ -48,9 +48,11 @@ public class UserManager implements Listener, UserHandler<Player, SunscreenUser<
     public void onLeave(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
         SunscreenUser<Player> user = userMap.get(player.getUniqueId());
-        Session session = user.session();
-        if (session != null) {
-            session.menu().close();
+        if (user != null) {
+            Session session = user.session();
+            if (session != null) {
+                session.menu().close();
+            }
         }
         userMap.remove(player.getUniqueId());
     }
@@ -66,7 +68,11 @@ public class UserManager implements Listener, UserHandler<Player, SunscreenUser<
 
     @Override
     public Optional<SunscreenUser<Player>> user(String s) {
-        return Optional.ofNullable(userMap.get(Bukkit.getPlayer(s).getUniqueId()));
+        final Player player = Bukkit.getPlayer(s);
+        if (player == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(userMap.get(player.getUniqueId()));
     }
 
     @Override

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserManager.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserManager.java
@@ -48,11 +48,14 @@ public class UserManager implements Listener, UserHandler<Player, SunscreenUser<
     public void onLeave(PlayerQuitEvent event) {
         final Player player = event.getPlayer();
         SunscreenUser<Player> user = userMap.get(player.getUniqueId());
-        if (user != null) {
-            Session session = user.session();
-            if (session != null) {
-                session.menu().close();
-            }
+        if (user == null) {
+            userMap.remove(player.getUniqueId());
+            return;
+        }
+
+        Session session = user.session();
+        if (session != null) {
+            session.menu().close();
         }
         userMap.remove(player.getUniqueId());
     }


### PR DESCRIPTION
This PR cleans up a few issues in the Paper/Spigot path that were causing unstable behavior around menu sessions, input handling, and entity cleanup.

  ### Changes i made 😭

  - Removed unsafe parallel component loading in ActiveMenu (race risk on map writes).
  - Fixed InputHandler to dispatch events from the updated input context.
  - Removed duplicate input event posting in ProtocolListener.
  - Fixed menu map-packet handling flow while a user is in a menu.
  - Fixed SpigotPlatformProtocolIntermediate#reset so it only removes entities tracked for the current player.
  - Implemented UserImpl#open(...) to actually open a menu and return a real session.
  - Hardened UserManager:
      - switched WeakHashMap -> HashMap
      - added null-safe handling on quit/name lookup paths
  - Updated build-system toolchain from Java 24 to Java 25.