### PR TITLE
WIP: Fabric client + server mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ gradle.properties
 
 # Run server task files
 spigot/run/
+fabric/run/
 
 # Generated files
 .idea/**/contentModel.xml
@@ -185,3 +186,7 @@ gradle-app.setting
 # .DS-STORE
 **/.DS_Store
 gradle.properties
+
+# Resourcepack
+/resourcepack/
+api/src/main/resources/

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,6 +8,10 @@ repositories {
 }
 
 dependencies {
+    implementation("com.google.code.gson:gson:2.11.0")
+    implementation("io.netty:netty-buffer:4.1.115.Final")
+    implementation("at.yawk.lz4:lz4-java:1.10.4")
+
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.platform:junit-platform-suite:1.13.4")
@@ -18,6 +22,7 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    failOnNoDiscoveredTests = false
 }
 
 tasks.register<JavaExec>("jmh") {

--- a/api/src/main/java/me/combimagnetron/sunscreen/nativeui/ClientRasterTile.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/nativeui/ClientRasterTile.java
@@ -1,0 +1,16 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import me.combimagnetron.passport.util.math.Vec3f;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+
+/** One 128× (or sub) tile from the client render pipeline, ready for GPU upload. */
+public record ClientRasterTile(
+    @NotNull BigDecimal scale,
+    @NotNull Vec3f gridPosition,
+    int width,
+    int height,
+    int @NotNull [] argbPixels
+) {
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/nativeui/MenuRasterWireCodec.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/nativeui/MenuRasterWireCodec.java
@@ -1,0 +1,212 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import me.combimagnetron.passport.util.math.Vec3f;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public final class MenuRasterWireCodec {
+    private static final int MAX_PIXELS = 1 << 22;
+    /** Raw LZ4 block codec (wire header supplies raw/compressed lengths; no LZ4 frame wrapper). */
+    private static final LZ4Factory LZ4_FACTORY = LZ4Factory.fastestInstance();
+
+    private static Encoder encoder;
+    private static Decoder decoder;
+
+    private MenuRasterWireCodec() {
+    }
+
+    public record DecodedFrame(
+        int logicalWidth,
+        int logicalHeight,
+        @NotNull List<ClientRasterTile> tiles
+    ) {
+    }
+
+    public static @NotNull Encoder encoder() {
+        if (encoder == null) encoder = new Encoder();
+        return encoder;
+    }
+
+    public static @NotNull Decoder decoder() {
+        if (decoder == null) decoder = new Decoder();
+        return decoder;
+    }
+
+    public static final class Encoder implements AutoCloseable {
+        private final ByteBuffer raw = ByteBuffer.allocate(1 << 24);
+        private final LZ4Compressor compressor = LZ4_FACTORY.fastCompressor();
+
+        private boolean closed;
+
+        private Encoder() {
+        }
+
+        public synchronized ByteBuffer writeTiles(
+            int logicalWidth,
+            int logicalHeight,
+            @NotNull List<ClientRasterTile> tiles
+        ) {
+            ensureOpen();
+            raw.clear();
+            if (logicalWidth <= 0 || logicalHeight <= 0) {
+                throw new IllegalArgumentException("Canvas dimensions must be positive");
+            }
+            raw.putInt(tiles.size());
+            for (ClientRasterTile t : tiles) {
+                writeUtf(raw, t.scale().toPlainString());
+                raw.putFloat(t.gridPosition().x());
+                raw.putFloat(t.gridPosition().y());
+                raw.putFloat(t.gridPosition().z());
+                raw.putInt(t.width());
+                raw.putInt(t.height());
+
+                int[] px = t.argbPixels();
+                if (px.length > MAX_PIXELS) {
+                    throw new IllegalArgumentException("Invalid pixel buffer length: " + px.length);
+                }
+                raw.putInt(px.length);
+                var pos = raw.position();
+                raw.asIntBuffer().put(px);
+                raw.position(pos + (px.length * Integer.BYTES));
+            }
+            raw.putInt(logicalWidth);
+            raw.putInt(logicalHeight);
+
+            int rawLen = raw.position();
+            int maxCompressed = compressor.maxCompressedLength(rawLen);
+            byte[] compressed = new byte[maxCompressed];
+            int compressedLen = compressor.compress(raw.array(), 0, rawLen, compressed, 0);
+
+            byte[] frame = new byte[Integer.BYTES * 2 + compressedLen];
+            ByteBuffer out = ByteBuffer.wrap(frame).order(ByteOrder.BIG_ENDIAN);
+            out.putInt(rawLen);
+            out.putInt(compressedLen);
+            out.put(compressed, 0, compressedLen);
+            out.flip();
+            return out;
+        }
+
+        private void ensureOpen() {
+            if (closed) {
+                throw new IllegalStateException("Encoder already closed");
+            }
+        }
+
+        @Override
+        public synchronized void close() {
+            closed = true;
+        }
+    }
+
+    public static final class Decoder implements AutoCloseable {
+        private static final LZ4FastDecompressor DECOMPRESSOR = LZ4_FACTORY.fastDecompressor();
+
+        private boolean closed;
+
+        private Decoder() {
+        }
+
+        private void decompress(byte @NotNull [] compressedBytes, int compressedLen, byte @NotNull [] dst) {
+            int consumed = DECOMPRESSOR.decompress(compressedBytes, 0, dst, 0, dst.length);
+            if (consumed != compressedLen) {
+                throw new IllegalStateException(
+                    "LZ4 decode length mismatch: consumed " + consumed + ", expected " + compressedLen
+                );
+            }
+        }
+
+        public synchronized @NotNull DecodedFrame readFrame(@NotNull ByteBuffer frameInput) {
+            ensureOpen();
+            ByteBuffer frame = frameInput.order(ByteOrder.BIG_ENDIAN);
+            int rawLen = frame.getInt();
+            if (rawLen < 0 || rawLen > MAX_PIXELS * Integer.BYTES * 4) {
+                throw new IllegalArgumentException("Invalid frame raw length: " + rawLen);
+            }
+            int compressedLen = frame.getInt();
+            if (compressedLen < 0 || compressedLen > frame.remaining()) {
+                throw new IllegalArgumentException(
+                    "Invalid frame compressed length: " + compressedLen + " for remaining bytes " + frame.remaining()
+                );
+            }
+
+            byte[] rawBytes = new byte[rawLen];
+            byte[] compressedBytes = new byte[compressedLen];
+            frame.get(compressedBytes);
+            decompress(compressedBytes, compressedLen, rawBytes);
+            ByteBuffer raw = ByteBuffer.wrap(rawBytes).order(ByteOrder.BIG_ENDIAN);
+
+            var size = raw.getInt();
+            List<ClientRasterTile> out = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                out.add(readTileAfterOpcode(raw));
+            }
+            var logicalW = raw.getInt();
+            var logicalH = raw.getInt();
+            if (raw.hasRemaining()) {
+                throw new IllegalArgumentException("Trailing bytes in decompressed frame: " + raw.remaining());
+            }
+            return new DecodedFrame(logicalW, logicalH, out);
+        }
+
+        private @NotNull ClientRasterTile readTileAfterOpcode(@NotNull ByteBuffer raw) {
+            BigDecimal scale = new BigDecimal(readUtf(raw));
+            float gx = raw.getFloat();
+            float gy = raw.getFloat();
+            float gz = raw.getFloat();
+            int w = raw.getInt();
+            int h = raw.getInt();
+
+            int len = raw.getInt();
+            if (len < 0 || len > MAX_PIXELS) {
+                throw new IllegalArgumentException("Invalid pixel buffer length: " + len);
+            }
+            if (len > raw.remaining() / Integer.BYTES) {
+                throw new IllegalArgumentException("Truncated pixel data in frame");
+            }
+            int[] px = new int[len];
+            raw.asIntBuffer().get(px);
+            raw.position(raw.position() + len * Integer.BYTES);
+
+            return new ClientRasterTile(scale, Vec3f.of(gx, gy, gz), w, h, px);
+        }
+
+        /** @deprecated Prefer {@link #readFrame(ByteBuffer)} for canvas dimensions. */
+        @Deprecated
+        public synchronized @NotNull List<ClientRasterTile> readTiles(@NotNull ByteBuffer frameInput) {
+            return readFrame(frameInput).tiles();
+        }
+
+        private void ensureOpen() {
+            if (closed) {
+                throw new IllegalStateException("Decoder already closed");
+            }
+        }
+
+        @Override
+        public synchronized void close() {
+            closed = true;
+        }
+    }
+
+    private static void writeUtf(@NotNull ByteBuffer out, @NotNull String s) {
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        out.putInt(bytes.length);
+        out.put(bytes);
+    }
+
+    private static @NotNull String readUtf(@NotNull ByteBuffer buf) {
+        int len = buf.getInt();
+        byte[] bytes = new byte[len];
+        buf.get(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUi.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUi.java
@@ -1,0 +1,321 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.neo.render.Viewport;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+/**
+ * Native UI transport: platform implementations send/receive chunked frames; this type exposes
+ * high-level {@linkplain #clientToServer client} and {@linkplain #serverToClient server} sends plus shared codecs.
+ */
+public interface NativeUi {
+    String CHANNEL = "sunscreen:native_ui";
+    byte C2S_HANDSHAKE = 1;
+    byte C2S_MENU_ACTION = 2;
+    byte S2C_RASTER = 1;
+    byte S2C_MENU_CLOSE = 2;
+    int SPIGOT_INNER_CHUNK_SAFE = 31_000;
+    int FABRIC_INNER_CHUNK_SAFE = 1024 * 1024;
+    int MAX_MENU_INSTANCE_ID_UTF8_BYTES = 512;
+    UUID CLIENT_S2C_SLOT = new UUID(0L, 0L);
+    NativeUiChunkBinary.Reassembler CLIENT_S2C_REASSEMBLER = new NativeUiChunkBinary.Reassembler();
+
+    /** Sub-opcodes under {@link #C2S_MENU_ACTION}: {@code [sub][body...]}. */
+    interface MenuInput {
+        byte MOUSE = 1;
+        byte SCROLL = 2;
+        byte TEXT_APPEND = 3;
+        byte TEXT_BACKSPACE = 4;
+        int MAX_TEXT_APPEND_UTF8_BYTES = 8192;
+    }
+
+    default void clientToServer(@NotNull ByteBuffer logical) {
+    }
+
+    /**
+     * Sends one fully prepared packet payload (already chunk envelope encoded) to the client.
+     */
+    void serverToClient(@NotNull SunscreenUser<?> user, @NotNull ByteBuffer payloadPacket);
+
+    default void clientHandshake(boolean supportsNativeUi) {
+        ByteBuffer out = ByteBuffer.allocate(2);
+        out.put(C2S_HANDSHAKE);
+        out.put((byte) (supportsNativeUi ? 1 : 0));
+        out.flip();
+        clientToServer(out);
+    }
+
+    default void clientMenuMouse(int lx, int ly, boolean left, boolean right) {
+        ByteBuffer out = ByteBuffer.allocate(11).order(ByteOrder.BIG_ENDIAN);
+        out.put(C2S_MENU_ACTION);
+        out.put(MenuInput.MOUSE);
+        out.putInt(lx);
+        out.putInt(ly);
+        out.put((byte) ((left ? 1 : 0) | (right ? 2 : 0)));
+        out.flip();
+        clientToServer(out);
+    }
+
+    default void clientMenuScroll(float dy) {
+        ByteBuffer out = ByteBuffer.allocate(6).order(ByteOrder.BIG_ENDIAN);
+        out.put(C2S_MENU_ACTION);
+        out.put(MenuInput.SCROLL);
+        out.putFloat(dy);
+        out.flip();
+        clientToServer(out);
+    }
+
+    default void clientMenuTextAppend(@NotNull String chars) {
+        byte[] utf8 = chars.getBytes(StandardCharsets.UTF_8);
+        if (utf8.length > MenuInput.MAX_TEXT_APPEND_UTF8_BYTES) {
+            throw new IllegalArgumentException("text exceeds " + MenuInput.MAX_TEXT_APPEND_UTF8_BYTES + " UTF-8 bytes");
+        }
+        ByteBuffer out = ByteBuffer.allocate(2 + 4 + utf8.length).order(ByteOrder.BIG_ENDIAN);
+        out.put(C2S_MENU_ACTION);
+        out.put(MenuInput.TEXT_APPEND);
+        out.putInt(utf8.length);
+        out.put(utf8);
+        out.flip();
+        clientToServer(out);
+    }
+
+    default void clientMenuTextBackspace() {
+        ByteBuffer out = ByteBuffer.allocate(2);
+        out.put(C2S_MENU_ACTION);
+        out.put(MenuInput.TEXT_BACKSPACE);
+        out.flip();
+        clientToServer(out);
+    }
+
+    default void serverSendTiles(@NotNull SunscreenUser<?> user, List<ClientRasterTile> tiles) {
+        if (tiles.isEmpty()) {
+            return;
+        }
+        var session = user.session();
+        if (session == null) return;
+        Viewport vp = user.screenInfo().viewport();
+        int logicalW = vp.currentView().x();
+        int logicalH = vp.currentView().y();
+        var payload = MenuRasterWireCodec.encoder().writeTiles(logicalW, logicalH, tiles);
+        var arr = payload.array();
+        var menuInstanceId = session.menu().identifier().string();
+        byte[] id = menuInstanceId.getBytes(StandardCharsets.UTF_8);
+        if (id.length > MAX_MENU_INSTANCE_ID_UTF8_BYTES) {
+            throw new IllegalArgumentException("menu instance id too long: " + id.length);
+        }
+        ByteBuffer out = ByteBuffer.allocate(1 + 4 + id.length + arr.length).order(ByteOrder.BIG_ENDIAN);
+        out.put(S2C_RASTER);
+        out.putInt(id.length);
+        out.put(id);
+        out.put(arr);
+        out.flip();
+        for (NativeUiChunkBinary.ChunkSlice slice : NativeUiChunkBinary.sliceLogical(out, SPIGOT_INNER_CHUNK_SAFE)) {
+            serverToClient(
+                user,
+                NativeUiChunkBinary.encode(slice.totalSize(), slice.chunkIndex(), slice.chunkCount(), slice.chunk())
+            );
+        }
+    }
+
+    default void serverCloseMenu(@NotNull SunscreenUser<?> user) {
+        ByteBuffer out = ByteBuffer.allocate(1);
+        out.put(S2C_MENU_CLOSE);
+        out.flip();
+        serverToClient(user, NativeUiChunkBinary.encode(1, 0, 1, new byte[] {S2C_MENU_CLOSE}));
+    }
+
+    /**
+     * After reassembling a C2S logical buffer on the server.
+     */
+    static void receiveServerC2S(@NotNull SunscreenUser<?> user, @NotNull ByteBuffer logical) {
+        if (!logical.hasRemaining()) {
+            return;
+        }
+        ByteBuffer buf = logical.slice().order(ByteOrder.BIG_ENDIAN);
+        byte type = buf.get();
+        switch (type) {
+            case C2S_HANDSHAKE -> {
+                if (buf.remaining() < 1) {
+                    user.setNativeUi(false);
+                    return;
+                }
+                boolean supports = buf.get() != 0;
+                if (!supports) {
+                    user.setNativeUi(false);
+                    return;
+                }
+                user.setNativeUi(true);
+            }
+            case C2S_MENU_ACTION -> {
+                if (buf.remaining() < 1) {
+                    return;
+                }
+                var session = SunscreenLibrary.library().sessionHandler().session(user);
+                if (session != null) {
+                    deliverNativeMenuClientAction(session.menu(), buf.slice());
+                }
+            }
+            default -> SunscreenLibrary.library().logger().warn(
+                "Unknown native UI C2S type {} from {}",
+                c2sName(type),
+                user
+            );
+        }
+    }
+
+    /**
+     * Platform server receivers pass raw packet bytes here; API decodes chunk header and dispatches C2S logical payload.
+     */
+    static void receiveServerC2SPacket(@NotNull SunscreenUser<?> user, byte @NotNull [] packetBytes) {
+        NativeUiChunkBinary.ChunkSlice slice = NativeUiChunkBinary.decode(ByteBuffer.wrap(packetBytes));
+        if (slice.chunkCount() != 1 || slice.chunkIndex() != 0 || slice.totalSize() != slice.chunk().length) {
+            SunscreenLibrary.library().logger().warn("Native UI C2S must be single-chunk.");
+            return;
+        }
+        receiveServerC2S(user, ByteBuffer.wrap(slice.chunk()));
+    }
+
+    /**
+     * Platform client receivers pass raw packet bytes here; API decodes chunk header and reassembles when needed.
+     *
+     * @return completed logical S2C payload or {@code null} while waiting for more chunks
+     */
+    static @Nullable ByteBuffer receiveClientS2CPacket(byte @NotNull [] packetBytes) {
+        NativeUiChunkBinary.ChunkSlice slice = NativeUiChunkBinary.decode(ByteBuffer.wrap(packetBytes));
+        if (slice.chunkCount() == 1) {
+            if (slice.chunkIndex() != 0 || slice.totalSize() != slice.chunk().length) {
+                SunscreenLibrary.library().logger().warn("Malformed native UI S2C single-chunk envelope.");
+                return null;
+            }
+            return ByteBuffer.wrap(slice.chunk());
+        }
+        byte[] full = CLIENT_S2C_REASSEMBLER.pushMulti(
+            CLIENT_S2C_SLOT,
+            slice.totalSize(),
+            slice.chunkIndex(),
+            slice.chunkCount(),
+            slice.chunk()
+        );
+        return full == null ? null : ByteBuffer.wrap(full);
+    }
+
+    static void resetClientS2CReassembly() {
+        CLIENT_S2C_REASSEMBLER.resetAll();
+    }
+
+    /**
+     * Decodes {@code logical[offset..endExclusive)} as {@code [sub-op][body]} and invokes the matching handler.
+     */
+    private static void deliverNativeMenuClientAction(
+        @NotNull me.combimagnetron.sunscreen.neo.ActiveMenu menu,
+        @NotNull ByteBuffer subFrame
+    ) {
+        if (!subFrame.hasRemaining()) {
+            return;
+        }
+        ByteBuffer buf = subFrame.slice().order(ByteOrder.BIG_ENDIAN);
+        byte sub = buf.get();
+        switch (sub) {
+            case MenuInput.MOUSE -> {
+                if (buf.remaining() < 9) {
+                    return;
+                }
+                int lx = buf.getInt();
+                int ly = buf.getInt();
+                byte flags = buf.get();
+                boolean left = (flags & 1) != 0;
+                boolean right = (flags & 2) != 0;
+                menu.acceptNativeClientMouse(lx, ly, left, right);
+            }
+            case MenuInput.SCROLL -> {
+                if (buf.remaining() < 4) {
+                    return;
+                }
+                menu.acceptNativeClientScroll(buf.getFloat());
+            }
+            case MenuInput.TEXT_APPEND -> {
+                if (buf.remaining() < 4) {
+                    return;
+                }
+                int len = buf.getInt();
+                if (len < 0 || len > MenuInput.MAX_TEXT_APPEND_UTF8_BYTES || buf.remaining() < len) {
+                    SunscreenLibrary.library().logger().warn("Invalid native text append length: {}", len);
+                    return;
+                }
+                byte[] utf8 = new byte[len];
+                buf.get(utf8);
+                String chars = new String(utf8, StandardCharsets.UTF_8);
+                if (!chars.isEmpty()) {
+                    menu.acceptNativeClientTextAppend(chars);
+                }
+            }
+            case MenuInput.TEXT_BACKSPACE -> menu.acceptNativeClientTextBackspace();
+            default -> SunscreenLibrary.library().logger().warn("Unknown native menu input sub-op: {}", sub);
+        }
+    }
+
+    static @NotNull S2CLogical decodeClientS2C(@NotNull ByteBuffer logical) {
+        if (!logical.hasRemaining()) {
+            return S2CLogical.unknown();
+        }
+        ByteBuffer buf = logical.slice().order(ByteOrder.BIG_ENDIAN);
+        return switch (buf.get()) {
+            case S2C_MENU_CLOSE -> S2CLogical.close();
+            case S2C_RASTER -> {
+                if (buf.remaining() < 4) {
+                    yield S2CLogical.unknown();
+                }
+                int idLen = buf.getInt();
+                if (idLen < 0 || idLen > MAX_MENU_INSTANCE_ID_UTF8_BYTES || buf.remaining() < idLen) {
+                    yield S2CLogical.unknown();
+                }
+                byte[] idBytes = new byte[idLen];
+                buf.get(idBytes);
+                String menuId = new String(idBytes, StandardCharsets.UTF_8);
+                ByteBuffer wire = ByteBuffer.allocate(buf.remaining());
+                wire.put(buf);
+                wire.flip();
+                yield S2CLogical.raster(menuId, wire);
+            }
+            default -> S2CLogical.unknown();
+        };
+    }
+
+    sealed interface S2CLogical {
+        record Close() implements S2CLogical {
+        }
+
+        record Raster(@NotNull String menuInstanceId, @NotNull ByteBuffer rasterWire) implements S2CLogical {
+        }
+
+        record Unknown() implements S2CLogical {
+        }
+
+        static @NotNull Close close() {
+            return new Close();
+        }
+
+        static @NotNull Raster raster(@NotNull String menuInstanceId, @NotNull ByteBuffer rasterWire) {
+            return new Raster(menuInstanceId, rasterWire);
+        }
+
+        static @NotNull Unknown unknown() {
+            return new Unknown();
+        }
+    }
+
+    private static @NotNull String c2sName(byte type) {
+        return switch (type) {
+            case C2S_HANDSHAKE -> "C2S_HANDSHAKE";
+            case C2S_MENU_ACTION -> "C2S_MENU_ACTION";
+            default -> "C2S_UNKNOWN(" + type + ")";
+        };
+    }
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUiChunkBinary.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUiChunkBinary.java
@@ -1,0 +1,162 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Chunk envelope: {@code totalSize, chunkIndex, chunkCount, chunk bytes}. Only large S2C rasters use
+ * {@code chunkCount > 1}; all other payloads are a single physical packet.
+ */
+public final class NativeUiChunkBinary {
+    public record ChunkSlice(
+        int totalSize,
+        int chunkIndex,
+        int chunkCount,
+        byte @NotNull [] chunk
+    ) {
+    }
+
+    private NativeUiChunkBinary() {
+    }
+
+    public static @NotNull ByteBuffer encode(
+        int totalSize,
+        int chunkIndex,
+        int chunkCount,
+        byte @NotNull [] chunk
+    ) {
+        ByteBuffer out = ByteBuffer.allocate(16 + chunk.length).order(ByteOrder.BIG_ENDIAN);
+        out.putInt(totalSize);
+        out.putInt(chunkIndex);
+        out.putInt(chunkCount);
+        out.putInt(chunk.length);
+        out.put(chunk);
+        out.flip();
+        return out;
+    }
+
+    public static @NotNull ChunkSlice decode(@NotNull ByteBuffer message) {
+        ByteBuffer buf = message.slice().order(ByteOrder.BIG_ENDIAN);
+        if (buf.remaining() < 16) {
+            throw new IllegalArgumentException("Truncated chunk envelope");
+        }
+        int totalSize = buf.getInt();
+        int chunkIndex = buf.getInt();
+        int chunkCount = buf.getInt();
+        int chunkLen = buf.getInt();
+        if (chunkLen < 0 || buf.remaining() < chunkLen) {
+            throw new IllegalArgumentException("Invalid chunk length: " + chunkLen);
+        }
+        byte[] chunk = new byte[chunkLen];
+        buf.get(chunk);
+        return new ChunkSlice(totalSize, chunkIndex, chunkCount, chunk);
+    }
+
+    /**
+     * Splits {@code logical} when it exceeds {@code maxInnerChunkBytes}; otherwise one slice with {@code chunkCount == 1}.
+     */
+    public static @NotNull List<ChunkSlice> sliceLogical(@NotNull ByteBuffer logical, int maxInnerChunkBytes) {
+        if (maxInnerChunkBytes < 1) {
+            throw new IllegalArgumentException("maxInnerChunkBytes");
+        }
+        ByteBuffer src = logical.slice();
+        int n = src.remaining();
+        if (n == 0) {
+            throw new IllegalArgumentException("empty logical payload");
+        }
+        if (n <= maxInnerChunkBytes) {
+            byte[] single = new byte[n];
+            src.get(single);
+            return List.of(new ChunkSlice(n, 0, 1, single));
+        }
+        int total = (n + maxInnerChunkBytes - 1) / maxInnerChunkBytes;
+        List<ChunkSlice> out = new ArrayList<>(total);
+        int basePos = src.position();
+        for (int idx = 0; idx < total; idx++) {
+            int from = idx * maxInnerChunkBytes;
+            int len = Math.min(maxInnerChunkBytes, n - from);
+            byte[] part = new byte[len];
+            ByteBuffer dup = src.duplicate();
+            dup.position(basePos + from);
+            dup.get(part);
+            out.add(new ChunkSlice(n, idx, total, part));
+        }
+        return out;
+    }
+
+    /**
+     * Incremental reassembly state keyed by sender/receiver identity.
+     */
+    public static final class Reassembler {
+        private final ConcurrentHashMap<UUID, State> states = new ConcurrentHashMap<>();
+
+        /**
+         * @return assembled payload when last chunk arrives; {@code null} while incomplete
+         */
+        public @Nullable byte[] pushMulti(
+            @NotNull UUID key,
+            int totalSize,
+            int chunkIndex,
+            int chunkCount,
+            byte @NotNull [] chunk
+        ) {
+            if (chunkCount <= 1) {
+                throw new IllegalArgumentException("chunkCount must be > 1");
+            }
+            if (chunkIndex < 0 || chunkIndex >= chunkCount) {
+                throw new IllegalArgumentException("Bad chunk indices: " + chunkIndex + "/" + chunkCount);
+            }
+            State st = states.compute(key, (id, prev) -> {
+                if (prev == null || prev.totalSize != totalSize || prev.chunkCount != chunkCount) {
+                    if (chunkIndex != 0) {
+                        throw new IllegalStateException("Missing initial chunk for multi-chunk transfer");
+                    }
+                    return new State(totalSize, chunkCount);
+                }
+                return prev;
+            });
+            synchronized (st) {
+                if (st.totalSize != totalSize || st.chunkCount != chunkCount) {
+                    states.remove(key);
+                    throw new IllegalStateException("Chunk metadata changed mid-transfer");
+                }
+                st.buffer.put(chunk);
+                if (chunkIndex + 1 < chunkCount) {
+                    return null;
+                }
+                states.remove(key);
+                st.buffer.flip();
+                byte[] full = new byte[st.buffer.remaining()];
+                st.buffer.get(full);
+                return full;
+            }
+        }
+
+        public void reset(@NotNull UUID key) {
+            states.remove(key);
+        }
+
+        public void resetAll() {
+            states.clear();
+        }
+
+        private static final class State {
+            final int totalSize;
+            final int chunkCount;
+            final ByteBuffer buffer;
+
+            State(int totalSize, int chunkCount) {
+                this.totalSize = totalSize;
+                this.chunkCount = chunkCount;
+                this.buffer = ByteBuffer.allocate(totalSize);
+            }
+        }
+    }
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUiClientNativeSupport.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/nativeui/NativeUiClientNativeSupport.java
@@ -1,0 +1,22 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.ByteBuffer;
+
+/**
+ * C2S one-way native UI availability (Minecraft-agnostic). Platform code wraps this in its payload type.
+ */
+public record NativeUiClientNativeSupport(boolean supportsNativeUi) {
+    public void write(@NotNull ByteBuffer buffer) {
+        buffer.put((byte) (supportsNativeUi ? 1 : 0));
+    }
+
+    public static @NotNull NativeUiClientNativeSupport read(@NotNull ByteBuffer buffer) {
+        return new NativeUiClientNativeSupport(buffer.get() != 0);
+    }
+
+    public static @NotNull ByteBuffer allocateWriteBuffer() {
+        return ByteBuffer.allocate(Byte.BYTES);
+    }
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
@@ -11,30 +11,28 @@ import me.combimagnetron.sunscreen.neo.element.GenericInteractableModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.sunscreen.neo.graphic.text.Text;
 import me.combimagnetron.sunscreen.neo.input.InputHandler;
-import me.combimagnetron.sunscreen.neo.input.context.InputContext;
 import me.combimagnetron.sunscreen.neo.input.context.MouseInputContext;
 import me.combimagnetron.sunscreen.neo.input.context.ScrollInputContext;
+import me.combimagnetron.sunscreen.neo.input.context.TextInputContext;
 import me.combimagnetron.sunscreen.neo.layout.Layout;
 import me.combimagnetron.sunscreen.neo.loader.MenuComponent;
 import me.combimagnetron.sunscreen.neo.loader.MenuComponentLoaderContext;
 import me.combimagnetron.sunscreen.neo.property.Position;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.protocol.PlatformProtocolIntermediate;
-import me.combimagnetron.sunscreen.neo.protocol.type.EntityReference;
 import me.combimagnetron.sunscreen.neo.protocol.type.Location;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderPipeline;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderThreadPoolHandler;
 import me.combimagnetron.sunscreen.neo.session.Session;
+import me.combimagnetron.sunscreen.neo.theme.ModernTheme;
 import me.combimagnetron.sunscreen.user.SunscreenUser;
 import me.combimagnetron.sunscreen.util.IdentifierHolder;
-import me.combimagnetron.sunscreen.util.Scheduler;
-import org.checkerframework.checker.units.qual.A;
+import me.combimagnetron.sunscreen.util.helper.ElementSizeSeeder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class ActiveMenu implements IdentifierHolder {
@@ -42,6 +40,11 @@ public class ActiveMenu implements IdentifierHolder {
     private final Vector3d initialRotation;
     private final Identifier identifier;
     private final SunscreenUser<?> user;
+    /**
+     * When true, the client negotiated native UI and we skip spectate, horse, and map packets; the server still runs
+     * the render loop but streams rasters instead of map updates.
+     */
+    private final boolean useNativeClientPath;
     private RenderPipeline renderPipeline;
     private MenuRoot menuRoot = new MenuRoot();
     private InputHandler inputHandler = InputHandler.defaults(this);
@@ -50,12 +53,17 @@ public class ActiveMenu implements IdentifierHolder {
         this.initialRotation = user.rotation();
         this.user = user;
         this.identifier = identifier;
+        this.useNativeClientPath = user.useNativeUi();
         PlatformProtocolIntermediate intermediate = SunscreenLibrary.library().intermediate();
-        intermediate.gameTime(user);
+        if (!useNativeClientPath) {
+            intermediate.gameTime(user);
+        }
         show(template);
-        Location location = user.eyeLocation();
-        intermediate.spawnAndSpectateDisplay(user, location);
-        intermediate.spawnAndRideHorse(user, user.eyeLocation());
+        if (!useNativeClientPath) {
+            Location location = user.eyeLocation();
+            intermediate.spawnAndSpectateDisplay(user, location);
+            intermediate.spawnAndRideHorse(user, user.eyeLocation());
+        }
         SunscreenLibrary.library().sessionHandler().session(new Session(this, user));
     }
 
@@ -68,11 +76,13 @@ public class ActiveMenu implements IdentifierHolder {
             inputHandler.close();
             inputHandler = InputHandler.defaults(this);
             inputHandler.cursor(CursorStyle.pointer());
-            intermediate.removeMaps(user);
+            if (!useNativeClientPath) {
+                intermediate.removeMaps(user);
+            }
         }
         template.build(menuRoot);
         loadComponents();
-        intermediate.gameTime(user);
+        ElementSizeSeeder.seedMenuTree(menuRoot.elementLikes(), loadedTheme());
         for (ElementLike<?> elementLike : menuRoot.elementLikes()) {
             if (elementLike instanceof GenericInteractableModernElement<?, ?, ?> interactableModernElement) {
                 interactableModernElement.inputHandler(inputHandler);
@@ -92,6 +102,14 @@ public class ActiveMenu implements IdentifierHolder {
         }
     }
 
+    private @Nullable ModernTheme loadedTheme() {
+        return loadedComponents.values().stream()
+            .filter(ModernTheme.class::isInstance)
+            .map(ModernTheme.class::cast)
+            .findFirst()
+            .orElse(null);
+    }
+
     public @NotNull MenuRoot root() {
         return menuRoot;
     }
@@ -109,6 +127,7 @@ public class ActiveMenu implements IdentifierHolder {
     }
 
     public @NotNull ActiveMenu add(@NotNull ElementLike<?> @NotNull... elementLikes) {
+        ElementSizeSeeder.seedMenuTree(Arrays.asList(elementLikes), loadedTheme());
         renderPipeline.submit(elementLikes);
         return this;
     }
@@ -130,22 +149,83 @@ public class ActiveMenu implements IdentifierHolder {
     }
 
     public @NotNull ActiveMenu cursor(@NotNull CursorStyle style) {
+        if (useNativeClientPath) {
+            // TODO(?)
+            return this;
+        }
         PlatformProtocolIntermediate protocolIntermediate = SunscreenLibrary.library().intermediate();
         protocolIntermediate.setHorseArmor(user, style.asset());
         return this;
+    }
+
+
+    public void openVanillaTextCapture(@NotNull SunscreenUser<?> user) {
+        if (useNativeClientPath) {
+            return;
+        }
+        SunscreenLibrary.library().intermediate().openEmptyAnvil(user);
     }
 
     public @NotNull SunscreenUser<?> user() {
         return user;
     }
 
+    /**
+     * When true, cursor position must come from native client packets (e.g. raster UI), not from player look / map bridge.
+     */
+    public boolean useNativeClientPath() {
+        return useNativeClientPath;
+    }
+
+    public void acceptNativeClientMouse(int lx, int ly, boolean left, boolean right) {
+        if (!useNativeClientPath) {
+            return;
+        }
+        inputHandler.peek(
+            MouseInputContext.class,
+            old -> new MouseInputContext(old.active(), right, left, Vec2i.of(lx, ly)),
+            user
+        );
+    }
+
+    public void acceptNativeClientScroll(float dy) {
+        if (!useNativeClientPath) {
+            return;
+        }
+        inputHandler.peek(
+            ScrollInputContext.class,
+            old -> new ScrollInputContext(true, dy, old.lastSlot()),
+            user
+        );
+    }
+
+    public void acceptNativeClientTextAppend(@NotNull String chars) {
+        if (!useNativeClientPath) {
+            return;
+        }
+        inputHandler.peek(TextInputContext.class, old -> old.append(chars), user);
+    }
+
+    public void acceptNativeClientTextBackspace() {
+        if (!useNativeClientPath) {
+            return;
+        }
+        inputHandler.peek(TextInputContext.class, TextInputContext::deleteLastCodePoint, user);
+    }
+
     public void close() {
         SunscreenLibrary.library().sessionHandler().remove(user);
-        renderPipeline.stop();
+        if (renderPipeline != null) {
+            renderPipeline.stop();
+        }
         loadedComponents.clear();
         inputHandler.close();
         PlatformProtocolIntermediate intermediate = SunscreenLibrary.library().intermediate();
-        intermediate.removeMaps(user);
+        if (!useNativeClientPath) {
+            intermediate.removeMaps(user);
+        } else {
+            intermediate.serverCloseMenu(user);
+        }
         intermediate.reset(user, initialRotation);
     }
 

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/TestMenuTemplate.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/TestMenuTemplate.java
@@ -2,17 +2,26 @@ package me.combimagnetron.sunscreen.neo;
 
 import me.combimagnetron.passport.util.data.Identifier;
 import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.neo.editor.element.EditorElements;
 import me.combimagnetron.sunscreen.neo.editor.element.EditorNameElement;
 import me.combimagnetron.sunscreen.neo.element.Elements;
 import me.combimagnetron.sunscreen.neo.element.impl.SelectorElement;
 import me.combimagnetron.sunscreen.neo.element.impl.ButtonElement;
 import me.combimagnetron.sunscreen.neo.element.impl.text.TextFieldElement;
+import me.combimagnetron.sunscreen.neo.event.UserClickElementEvent;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.sunscreen.neo.graphic.NineSlice;
 import me.combimagnetron.sunscreen.neo.graphic.color.Color;
+import me.combimagnetron.sunscreen.neo.graphic.shape.Shape;
+import me.combimagnetron.sunscreen.neo.graphic.text.Text;
+import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.color.TextColor;
+import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.font.FontProperties;
 import me.combimagnetron.sunscreen.neo.property.Decorator;
 import me.combimagnetron.sunscreen.neo.property.Position;
+import me.combimagnetron.sunscreen.neo.property.RelativeMeasure;
 import me.combimagnetron.sunscreen.neo.property.Size;
+import me.combimagnetron.sunscreen.neo.registry.Registries;
 import me.combimagnetron.sunscreen.neo.theme.ModernTheme;
 import me.combimagnetron.sunscreen.neo.theme.color.ColorSchemes;
 import me.combimagnetron.sunscreen.neo.theme.decorator.Target;
@@ -21,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class TestMenuTemplate implements MenuTemplate {
     private static final Identifier IDENTIFIER = Identifier.of("sunscreen", "test_menu");
+    private static final Identifier FONT_SUNBURNED = Identifier.of("sunscreen", "font/sunburned");
+
     public static final ModernTheme THEME = ModernTheme.theme(
         Identifier.of(
             "sunscreen",
@@ -48,7 +59,7 @@ public class TestMenuTemplate implements MenuTemplate {
             .clicked(Canvas.resource("secondary_click.png"))
     ).decorator(
         ThemeDecorator.stated(
-            Target.typed(SelectorElement.class)
+                Target.typed(SelectorElement.class)
                 )
                     .standard(Canvas.resource("editor_assets/e_default.png"))
         .hovered(Canvas.resource("editor_assets/e_hover.png"))
@@ -60,6 +71,13 @@ public class TestMenuTemplate implements MenuTemplate {
         )
     );
 
+    private static @NotNull Text caption(@NotNull String content) {
+        return Text.basic(content)
+            .font(Registries.fonts().get(FONT_SUNBURNED))
+            .color(TextColor.color(Color.of(220, 220, 220)))
+            .fontProperties(FontProperties.properties().baseline(-6));
+    }
+
     @Override
     public @NotNull Identifier identifier() {
         return IDENTIFIER;
@@ -67,61 +85,196 @@ public class TestMenuTemplate implements MenuTemplate {
 
     @Override
     public void build(@NotNull MenuRoot root) {
-        root.theme(
-            THEME
-        );
-        root
-            .element(
-                Elements.button(
-                        Identifier.of(
-                            "sunscreen",
-                            "test_menu/element/button"
-                        )
-                    )
-                    .position(Position.fixed(Vec2i.of(450, 200))).size(Size.fixed(Vec2i.of(100, 20)))
-                    .decorator(Decorator.decorator(Target.identifier(Identifier.of("sunscreen", "decorator/secondary_button"))))
-            )/*.element(
+        root.theme(THEME);
+
+        root.element(
             Elements.image(
-                Identifier.of(
-                    "sunscreen",
-                    "test_menu/element/test_image"
-                ),
-                Canvas.empty(Vec2i.of(100, 100)).fill(Position.nil(), Size.fixed(Vec2i.of(100, 100)), Color.of(107, 3, 244))
-            ).position(Position.fixed(Vec2i.of(0, 0)))
+                Identifier.of("sunscreen", "test_menu/panel/backdrop"),
+                Canvas.empty(Vec2i.of(1000, 600)).fill(
+                    Vec2i.zero(),
+                    Vec2i.of(1000, 600),
+                    Color.of(0xD0101010, 0xD0101010, 0xE0101010, 0xE0101010)
+                )
+            ).position(Position.fixed(Vec2i.zero()))
+        ).element(
+            Elements.label(
+                Identifier.of("sunscreen", "test_menu/label/title"),
+                caption("Sunscreen interaction harness")
+            ).position(Position.fixed(Vec2i.of(14, 10)))
+        ).element(
+            Elements.label(
+                Identifier.of("sunscreen", "test_menu/label/hint"),
+                caption("Watch server log for click / text / selector events")
+            ).position(Position.fixed(Vec2i.of(14, 26)))
+        ).element(
+            new SelectorElement(Identifier.of("sunscreen", "test_menu/selector/tabs"), 12)
+                .entry(Text.vanilla("Alpha"))
+                .entry(Text.vanilla("Beta"))
+                .entry(Text.vanilla("Gamma"))
+                .position(Position.fixed(Vec2i.of(14, 46)))
+                .size(Size.fixed(Vec2i.of(200, 14)))
+                .listen()
+                .select(event ->
+                    SunscreenLibrary.library().logger().info(
+                        "Test harness tab select relative={} element={}",
+                        event.coords(),
+                        event.element().identifier()
+                    ))
+                .back()
+        ).element(
+            Elements.label(
+                Identifier.of("sunscreen", "test_menu/label/button_positioning_hint"),
+                caption("Buttons: manual text offset, auto-centered text, and center-anchored positioning")
+            ).position(Position.fixed(Vec2i.of(14, 60)))
+        ).element(
+            Elements.button(Identifier.of("sunscreen", "test_menu/button/primary"))
+                .position(Position.fixed(Vec2i.of(14, 84)))
+                .size(Size.fixed(Vec2i.of(120, 22)))
+                .listen()
+                .click(event -> logClick("primary", event))
+                .back()
+        ).element(
+            Elements.button(Identifier.of("sunscreen", "test_menu/button/secondary"))
+                .position(Position.fixed(Vec2i.of(144, 84)))
+                .size(Size.fixed(Vec2i.of(120, 22)))
+                .decorator(Decorator.decorator(Target.identifier(Identifier.of("sunscreen", "decorator/secondary_button"))))
+                .listen()
+                .click(event -> logClick("secondary", event))
+                .back()
         ).element(
             Elements.button(
-                Identifier.of(
-                    "sunscreen",
-                    "test_menu/element/button"
+                Identifier.of("sunscreen", "test_menu/button/labeled_manual"),
+                caption("Label xy"),
+                Vec2i.of(6, 5)
+            )
+                .position(Position.fixed(Vec2i.of(274, 84)))
+                .size(Size.fixed(Vec2i.of(120, 22)))
+                .listen()
+                .click(event -> logClick("labeled_manual", event))
+                .back()
+        ).element(
+            Elements.button(
+                Identifier.of("sunscreen", "test_menu/button/labeled_centered"),
+                caption("Centered label")
+            )
+                .position(Position.fixed(Vec2i.of(404, 84)))
+                .size(Size.fixed(Vec2i.of(140, 22)))
+                .listen()
+                .click(event -> logClick("labeled_centered", event))
+                .back()
+        ).element(
+            Elements.button(
+                Identifier.of("sunscreen", "test_menu/button/position_center_fixed"),
+                caption("Center target (fixed)")
+            )
+                .position(Position.fixed(Vec2i.of(500, 136)).target(Position.Target.CENTER))
+                .size(Size.fixed(Vec2i.of(170, 22)))
+                .listen()
+                .click(event -> logClick("position_center_fixed", event))
+                .back()
+        ).element(
+            Elements.button(
+                Identifier.of("sunscreen", "test_menu/button/position_center_relative"),
+                caption("Center target (relative)")
+            )
+                .position(
+                    Position.relative(
+                        RelativeMeasure.vec2i()
+                            .x().percentage(50).back()
+                            .y().percentage(50).pixel(-120).back()
+                    ).target(Position.Target.CENTER)
                 )
-            ).listen().mouse(event -> SunscreenLibrary.library().logger().debug(event.context().position().toString())).back()
-                .position(Position.fixed(Vec2i.of(450, 200))).size(Size.fixed(Vec2i.of(100, 20)))
+                .size(Size.fixed(Vec2i.of(182, 22)))
+                .listen()
+                .click(event -> logClick("position_center_relative", event))
+                .back()
+        ).element(
+            Elements.textField(Identifier.of("sunscreen", "test_menu/field/inline"))
+                .position(Position.fixed(Vec2i.of(14, 164)))
+                .size(Size.fixed(Vec2i.of(380, 24)))
+                .listen()
+                .updated(event -> SunscreenLibrary.library().logger().debug(
+                    "Test harness inline field: {}",
+                    event.context().stream().value()
+                ))
+                .back()
+        ).element(
+            Elements.label(
+                Identifier.of("sunscreen", "test_menu/label/anvil_hint"),
+                caption("Anvil field (clears on focus):")
+            ).position(Position.fixed(Vec2i.of(14, 194)))
+        ).element(
+            Elements.textField(Identifier.of("sunscreen", "test_menu/field/anvil"))
+                .shouldClear(true)
+                .position(Position.fixed(Vec2i.of(14, 210)))
+                .size(Size.fixed(Vec2i.of(380, 24)))
+                .listen()
+                .updated(event -> SunscreenLibrary.library().logger().info(
+                    "Test harness anvil field: {}",
+                    event.context().stream().value()
+                ))
+                .back()
+        ).element(
+            EditorElements.multiValue(Identifier.of("sunscreen", "test_menu/editor/multi_value"))
+                .position(Position.fixed(Vec2i.of(14, 246)))
+                .listen()
+                .selector(event -> SunscreenLibrary.library().logger().info(
+                    "Test harness multi-value drag: {}",
+                    event.context()
+                ))
+                .back()
+        ).element(
+            EditorElements.value(Identifier.of("sunscreen", "test_menu/editor/value_strip"))
+                .position(Position.fixed(Vec2i.of(164, 246)))
         ).element(
             Elements.shape(
-                Identifier.of(
-                "sunscreen",
-                "test_menu/element/test_shape"
-                ),
-                Shape.line(Vec2i.of(200, 322), Vec2i.of(600, 20), 3),
-                Color.of(0, 0, 0)
-            ).position(Position.fixed(Vec2i.of(200, 200)))
+                Identifier.of("sunscreen", "test_menu/shape/divider"),
+                Shape.line(Vec2i.zero(), Vec2i.of(360, 0), 2),
+                Color.of(90, 90, 120)
+            ).position(Position.fixed(Vec2i.of(14, 292)))
         ).element(
             Elements.image(
-                Identifier.of(
-                    "sunscreen",
-                    "test_menu/element/test_image_url"
-                ),
-                Canvas.url("https://i.imgur.com/YNMmJRM.png")
-            ).position(Position.fixed(Vec2i.of(200, 300)))//.position(Position.relative(RelativeMeasure.vec2i().x().percentage(50).back().y().percentage(50).back()))
+                Identifier.of("sunscreen", "test_menu/image/swatches"),
+                Canvas.empty(Vec2i.of(120, 72)).fill(
+                    Vec2i.zero(),
+                    Vec2i.of(120, 72),
+                    Color.of(107, 3, 244)
+                )
+            ).position(Position.fixed(Vec2i.of(14, 302)))
         ).element(
-            new MultiValueSelectorElement(Identifier.of("hello")).position(Position.fixed(Vec2i.of(660, 41)))
+            Elements.comparison(
+                Identifier.of("sunscreen", "test_menu/image/comparison"),
+                Canvas.resource("normal.png").replace(Color.of(205, 104, 61), Color.of(255, 0, 0)),
+                Canvas.resource("inverted.png")
+            )
+                .size(Size.fixed(Vec2i.of(160, 134)))
+                .position(Position.fixed(Vec2i.of(150, 302)))
         ).element(
-            Elements.textField(
-                Identifier.of("test")
-            ).position(Position.fixed(Vec2i.of(20, 300))).size(Size.fixed(Vec2i.of(700, 10)))
+            Elements.button(Identifier.of("sunscreen", "test_menu/button/move_probe"))
+                .position(Position.fixed(Vec2i.of(330, 302)))
+                .size(Size.fixed(Vec2i.of(140, 22)))
+                .listen()
+                .mouse(event ->
+                    SunscreenLibrary.library().logger().trace(
+                        "Test harness move_probe cursor={} left={}",
+                        event.context().position(),
+                        event.context().leftPressed()
+                    ))
+                .back()
         ).element(
-            Elements.comparison(Identifier.of("test"), Canvas.resource("normal.png").replace(Color.of(205, 104, 61), Color.of(255, 0, 0)), Canvas.resource("inverted.png")).size(Size.fixed(Vec2i.of(200, 168))).position(Position.relative(RelativeMeasure.vec2i().x().percentage(50).pixel(-100).back().y().percentage(50).pixel(-84).back()))
-        )*/;
+            Elements.button(Identifier.of("sunscreen", "test_menu/button/disabled"))
+                .position(Position.fixed(Vec2i.of(330, 332)))
+                .size(Size.fixed(Vec2i.of(140, 22)))
+                .disable()
+        );
+    }
+
+    private static void logClick(@NotNull String role, @NotNull UserClickElementEvent<?> event) {
+        SunscreenLibrary.library().logger().info(
+            "Test harness button [{}] click at relative={}",
+            role,
+            event.coords()
+        );
     }
 
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/EditorController.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/EditorController.java
@@ -156,7 +156,7 @@ public class EditorController {
         int y = 11;
         for (ArgumentInfo.TypeInfo typeInfo : provider.arguments().argumentTypes()) {
             Argument<?> argument = typeInfo.type().getConstructor().newInstance();
-            providerArgumentMap.computeIfAbsent(provider, (_) -> new ArrayList<>());
+            providerArgumentMap.computeIfAbsent(provider, (e) -> new ArrayList<>());
             providerArgumentMap.get(provider).add(argument);
             Collection<ModernElement<?, Canvas>> elements = (Collection<ModernElement<?, Canvas>>) argument.fields(Vec2i.of(0, y + 11));
             for (ModernElement<?, Canvas> element : elements) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/element/ValueSelectorElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/element/ValueSelectorElement.java
@@ -87,7 +87,7 @@ public class ValueSelectorElement extends GenericInteractableModernElement<Value
         Vec2i relativePos = cursor.sub(position);
         previous = hovered;
         hovered = Section.at(relativePos);
-        if (hovered != previous) {
+        if (hovered != previous || hovered == null) {
             startPos = null;
         }
         if (startPos == null) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/virtual/argument/ElementConstructionProvider.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/editor/virtual/argument/ElementConstructionProvider.java
@@ -158,7 +158,7 @@ public interface ElementConstructionProvider<M extends ModernElement<M, Canvas>>
     }
 
     static void defaults() {
-        Registry<ElementConstructionProvider<?>> elementConstructionProviderRegistry = Registries.constructionProviders();
+        Registry<ElementConstructionProvider<?>, Identifier> elementConstructionProviderRegistry = Registries.constructionProviders();
         for (ElementConstructionProvider<?> provider : PROVIDERS) {
             Registries.register(elementConstructionProviderRegistry, provider);
         }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/Elements.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/Elements.java
@@ -71,7 +71,7 @@ public interface Elements {
     }
 
     static @NotNull ButtonElement button(@NotNull Identifier identifier, @NotNull Text text) {
-        return new ButtonElement(identifier, text, Vec2i.zero());
+        return new ButtonElement(identifier, text);
     }
 
     static @NotNull ButtonElement button(@NotNull Identifier identifier, @NotNull Text text, @NotNull Vec2i position) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/ModernElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/ModernElement.java
@@ -1,9 +1,17 @@
 package me.combimagnetron.sunscreen.neo.element;
 
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.graphic.GraphicLike;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.Renderable;
+import org.jetbrains.annotations.Nullable;
 
 public interface ModernElement<E extends ModernElement<E, G>, G extends GraphicLike<G>> extends ElementLike<E>, Renderable<Size, G> {
 
+    /**
+     * Natural pixel size from content (bitmap, text, shape, etc.), or {@code null} if unknown without theme / explicit {@link Size}.
+     */
+    default @Nullable Vec2i intrinsicSize() {
+        return null;
+    }
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ButtonElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ButtonElement.java
@@ -13,10 +13,6 @@ import me.combimagnetron.sunscreen.neo.graphic.text.Text;
 import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.color.TextColor;
 import me.combimagnetron.sunscreen.neo.input.InputHandler;
 import me.combimagnetron.sunscreen.neo.input.ListenerReferences;
-import me.combimagnetron.sunscreen.neo.input.base.Action;
-import me.combimagnetron.sunscreen.neo.input.base.Module;
-import me.combimagnetron.sunscreen.neo.input.base.MouseInputBase;
-import me.combimagnetron.sunscreen.neo.input.base.impl.Modules;
 import me.combimagnetron.sunscreen.neo.input.context.MouseInputContext;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.property.Visibility;
@@ -34,7 +30,9 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
     private Text text;
     private ElementPhase phase = ElementPhase.DEFAULT;
     private int click = 0;
+    private boolean wasLeftPressed = false;
     private Vec2i textPosition = Vec2i.zero();
+    private boolean autoCenterText = false;
     private Canvas canvas;
 
     public ButtonElement(@NotNull Identifier identifier) {
@@ -48,6 +46,12 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
             this.textPosition = textPosition;
     }
 
+    public ButtonElement(@NotNull Identifier identifier, @Nullable Text label) {
+        super(identifier);
+        this.text = label;
+        this.autoCenterText = true;
+    }
+
     @Override
     protected void lateInit() {
         super.lateInit();
@@ -59,13 +63,27 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
         Vec2i size = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
     }
 
+    public @Nullable Text text() {
+        return text;
+    }
+
     public @NotNull ButtonElement text(@Nullable Text text) {
         this.text = text;
         return this;
     }
 
+    public @NotNull Vec2i textPosition() {
+        return textPosition;
+    }
+
     public @NotNull ButtonElement textPosition(@Nullable Vec2i position) {
         this.textPosition = position;
+        this.autoCenterText = false;
+        return this;
+    }
+
+    public @NotNull ButtonElement autoCenterText(boolean autoCenterText) {
+        this.autoCenterText = autoCenterText;
         return this;
     }
 
@@ -80,21 +98,36 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
         final MouseInputContext context = event.context();
         Vec2i cursor = context.position();
         boolean hover = HoverHelper.in(this, cursor);
-        if (hover && context.leftPressed())
+        boolean leftPressed = context.leftPressed();
+        boolean releaseInside = hover && wasLeftPressed && !leftPressed && click > 0;
+        if (hover && leftPressed)
             click = 3;
         InputHandler handler = inputHandler();
-        if (phase == ElementPhase.DISABLED) return;
+        if (phase == ElementPhase.DISABLED) {
+            wasLeftPressed = leftPressed;
+            return;
+        }
         if (!hover && phase != ElementPhase.DEFAULT) {
             phase = ElementPhase.DEFAULT;
             handler.cursor(CursorStyle.pointer());
+            wasLeftPressed = leftPressed;
             return;
         }
         Visibility visibility = visibility();
-        if (visibility.hide())
+        if (visibility.hide()) {
+            wasLeftPressed = leftPressed;
             return;
-        if (click == 1) {
+        }
+        if (releaseInside) {
+            Vec2i elementSize = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
             Dispatcher.dispatcher()
-                    .post(new UserClickElementEvent<>(event.user(), this, cursor.sub(position().value())));
+                .post(new UserClickElementEvent<>(event.user(), this, cursor.sub(position().resolve(elementSize))));
+            click = 0;
+        }
+        if (click == 1) {
+            Vec2i elementSize = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
+            Dispatcher.dispatcher()
+                    .post(new UserClickElementEvent<>(event.user(), this, cursor.sub(position().resolve(elementSize))));
         }
         if (click > 0) {
             click -= 1;
@@ -103,6 +136,11 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
             phase = ElementPhase.HOVER;
             handler.cursor(CursorStyle.click());
         }
+        if (click == 0 && hover && !context.leftPressed() && phase == ElementPhase.CLICK) {
+            phase = ElementPhase.HOVER;
+            handler.cursor(CursorStyle.click());
+        }
+        wasLeftPressed = leftPressed;
     }
 
     public @NotNull ButtonElement disabled(boolean disabled) {
@@ -142,7 +180,15 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
             Text buttonText = text;
             if (phase == ElementPhase.DISABLED) buttonText.color(TextColor.color(Color.of(93, 93, 93)));
             else buttonText.color(TextColor.color(Color.of(255, 255, 255)));
-            button.place(buttonText.render(size, context), textPosition);
+            Canvas renderedText = buttonText.render(size, context).trim();
+            Vec2i placePosition = textPosition;
+            if (autoCenterText) {
+                placePosition = Vec2i.of(
+                    (sizeVec.x() - renderedText.size().x()) / 2,
+                    (sizeVec.y() - renderedText.size().y()) / 2
+                );
+            }
+            button.place(renderedText, placePosition);
         }
         // button.modifier(GraphicModifiers.mask(Shape.rectangle(Vec2i.of(20, 20)),
         // ModifierContext.of()));
@@ -168,5 +214,4 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
         }
 
     }
-
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ComparisonElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ComparisonElement.java
@@ -94,15 +94,27 @@ public class ComparisonElement extends GenericInteractableModernElement<Comparis
     @Override
     public @NonNull Canvas render(@NonNull Size property, @Nullable RenderContext context) {
         if (context == null) return Canvas.error(size());
-        if (left == null || right == null || left.size().x() != right.size().x() || left.size().y() != right.size().y()) return Canvas.error(size());
-        final Canvas canvas = Canvas.empty(left.size());
-        final Vec2i size = left.size();
+        if (left == null || right == null) return Canvas.error(size());
+        final Vec2i targetSize = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
+        if (targetSize.x() <= 0 || targetSize.y() <= 0) return Canvas.error(size());
+        final Canvas leftCanvas = left.size().equals(targetSize)
+            ? left
+            : new Canvas(left.bufferedColorSpace().resize(targetSize), left.classpathResource());
+        final Canvas rightCanvas = right.size().equals(targetSize)
+            ? right
+            : new Canvas(right.bufferedColorSpace().resize(targetSize), right.classpathResource());
+        final Canvas canvas = Canvas.empty(targetSize);
+        final Vec2i size = targetSize;
         Vec2i tabSize = Vec2i.of(4, size.y());
         float valueF = (value/100f);
-        canvas.place(left, Vec2i.zero());
-        int section = right.size ().x() - (int) (valueF * right.size().x());
-        canvas.place(right.sub(Vec2i.of(right.size().x() - section, 0), Vec2i.of(section, right.size().y())), Vec2i.of(right.size().x() - section, 0));
-        canvas.place(Canvas.empty(tabSize).fill(Vec2i.zero(), tabSize, Color.of(39, 39, 39)), Vec2i.of((int) (valueF*size.x() - 2), 1));
+        canvas.place(leftCanvas, Vec2i.zero());
+        int section = rightCanvas.size().x() - (int) (valueF * rightCanvas.size().x());
+        canvas.place(
+            rightCanvas.sub(Vec2i.of(rightCanvas.size().x() - section, 0), Vec2i.of(section, rightCanvas.size().y())),
+            Vec2i.of(rightCanvas.size().x() - section, 0)
+        );
+        int tabX = Math.clamp((int) (valueF * size.x() - 2), 0, Math.max(0, size.x() - tabSize.x()));
+        canvas.place(Canvas.empty(tabSize).fill(Vec2i.zero(), tabSize, Color.of(39, 39, 39)), Vec2i.of(tabX, 1));
         return canvas;
     }
 

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ImageElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ImageElement.java
@@ -3,6 +3,7 @@ package me.combimagnetron.sunscreen.neo.element.impl;
 import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.GraphicLike;
 import me.combimagnetron.passport.util.data.Identifier;
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.engine.context.RenderContext;
 import org.jetbrains.annotations.NotNull;
@@ -15,6 +16,11 @@ public class ImageElement<G extends GraphicLike<G>> extends GenericModernElement
     public ImageElement(@NotNull Identifier identifier, @NotNull G graphicLike) {
         super(identifier);
         this.graphic = graphicLike;
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return graphic.bufferedColorSpace().size();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/LabelElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/LabelElement.java
@@ -7,7 +7,6 @@ import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.passport.util.data.Identifier;
 import me.combimagnetron.sunscreen.neo.graphic.text.Text;
-import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.font.FontProperties;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.engine.context.RenderContext;
 import me.combimagnetron.sunscreen.util.helper.PropertyHelper;
@@ -33,6 +32,14 @@ public class LabelElement extends GenericModernElement<LabelElement, Canvas> {
         MutableState<Text> componentMutableState = (MutableState<Text>) componentState;
         componentMutableState.observe((old, current) -> {
         });
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return text.value()
+            .render(Size.fixed(Vec2i.of(4096, 1024)), null)
+            .trim()
+            .size();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/SelectorElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/SelectorElement.java
@@ -85,7 +85,8 @@ public class SelectorElement extends GenericInteractableModernElement<SelectorEl
         }
         style = CursorStyle.click();
         handler.cursor(CursorStyle.click());
-        Vec2i relative = cursor.sub(position().value());
+        Vec2i size = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
+        Vec2i relative = cursor.sub(position().resolve(size));
         int index = indexAt(relative);
         hovered = index;
         if (index == -1)

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ShapeElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ShapeElement.java
@@ -1,6 +1,7 @@
 package me.combimagnetron.sunscreen.neo.element.impl;
 
 import me.combimagnetron.passport.util.data.Identifier;
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.sunscreen.neo.graphic.color.Color;
@@ -22,6 +23,15 @@ public class ShapeElement extends GenericModernElement<ShapeElement, Canvas> {
 
     public ShapeElement(@NotNull Identifier identifier, @NotNull Shape shape) {
         this(identifier, shape, Color.of(255, 255, 255));
+    }
+
+    public @NotNull Shape shape() {
+        return shape;
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return shape.squareSize();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/Canvas.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/Canvas.java
@@ -14,6 +14,8 @@ import me.combimagnetron.sunscreen.util.helper.PropertyHelper;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -24,7 +26,11 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.BitSet;
 
-public record Canvas(BufferedColorSpace bufferedColorSpace) implements GraphicLike<Canvas> {
+public record Canvas(BufferedColorSpace bufferedColorSpace, Optional<String> classpathResource) implements GraphicLike<Canvas> {
+
+    public Canvas(BufferedColorSpace bufferedColorSpace) {
+        this(bufferedColorSpace, Optional.empty());
+    }
 
     public Canvas(Vec2i size) {
         this(new BufferedColorSpace(size));
@@ -70,7 +76,8 @@ public record Canvas(BufferedColorSpace bufferedColorSpace) implements GraphicLi
     }
 
     public static @NotNull Canvas resource(@NotNull String string) {
-        return file(FileProvider.resource().find(string).toPath());
+        Canvas loaded = file(FileProvider.resource().find(string).toPath());
+        return new Canvas(loaded.bufferedColorSpace(), Optional.of(string));
     }
 
     public static @NotNull Canvas empty(@NotNull Vec2i size) {
@@ -146,7 +153,7 @@ public record Canvas(BufferedColorSpace bufferedColorSpace) implements GraphicLi
     }
 
     public @NotNull Canvas trim() {
-        return new Canvas(bufferedColorSpace.trim());
+        return new Canvas(bufferedColorSpace.trim(), classpathResource);
     }
 
     public @NotNull Canvas erase(@NotNull Vec2i position) {
@@ -155,11 +162,11 @@ public record Canvas(BufferedColorSpace bufferedColorSpace) implements GraphicLi
     }
 
     public @NotNull Canvas scale(float scale) {
-        return new Canvas(bufferedColorSpace.scale(scale));
+        return new Canvas(bufferedColorSpace.scale(scale), classpathResource);
     }
 
     public @NotNull Canvas sub(@NotNull Vec2i position, @NotNull Vec2i size) {
-        return new Canvas(bufferedColorSpace.sub(position.x(), position.y(), size.x(), size.y()));
+        return new Canvas(bufferedColorSpace.sub(position.x(), position.y(), size.x(), size.y()), classpathResource);
     }
 
     public @NotNull Canvas text(@NotNull Text text, @NotNull Vec2i position) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/NineSlice.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/NineSlice.java
@@ -24,6 +24,11 @@ public final class NineSlice {
         return new NineSlice(canvas, List.of(corners));
     }
 
+    /** Base image before slicing (used for native UI wire capture). */
+    public @NotNull Canvas sourceCanvas() {
+        return canvas;
+    }
+
     private NineSlice(@NotNull Canvas canvas) {
         this.canvas = canvas;
         final Vec2i size = canvas.size();

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/text/Text.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/text/Text.java
@@ -84,4 +84,18 @@ public sealed interface Text extends Renderable<Size, Canvas> permits TextImpl {
 
     @NotNull Text append(@NotNull Text text);
 
+    /**
+     * Plain text for network snapshots (best-effort; only {@link TextImpl} trees are supported).
+     */
+    default @NotNull String networkPlain() {
+        if (this instanceof TextImpl impl) {
+            StringBuilder sb = new StringBuilder(impl.contentString());
+            for (Text child : impl.children()) {
+                sb.append(child.networkPlain());
+            }
+            return sb.toString();
+        }
+        throw new IllegalArgumentException("Unsupported text type for network encoding: " + getClass().getName());
+    }
+
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/input/InputHandler.java
@@ -104,7 +104,7 @@ public class InputHandler {
     public void anvil(boolean shouldClear) {
         TextInputContext context = context(TextInputContext.class);
         String current = context.stream().value();
-        SunscreenLibrary.library().intermediate().openEmptyAnvil(activeMenu.user());
+        activeMenu.openVanillaTextCapture(activeMenu.user());
         peek(TextInputContext.class, old -> old.withActive(true), user());
         boolean reset = context(TextInputContext.class).reset();
         if (!shouldClear && reset) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/input/context/TextInputContext.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/input/context/TextInputContext.java
@@ -32,6 +32,21 @@ public record TextInputContext(boolean active, @NotNull State<String> stream, @N
         return new TextInputContext(active, State.immutable(stream.value() + content), State.immutable(additional.value() + content), reset);
     }
 
+    /**
+     * Removes the last Unicode code point from both {@link #stream} and {@link #additional}, keeping them aligned
+     * like {@link #append}.
+     */
+    public @NotNull TextInputContext deleteLastCodePoint() {
+        String s = stream.value();
+        String a = additional.value();
+        if (s.isEmpty() && a.isEmpty()) {
+            return this;
+        }
+        String ns = s.isEmpty() ? s : s.substring(0, s.offsetByCodePoints(s.length(), -1));
+        String na = a.isEmpty() ? a : a.substring(0, a.offsetByCodePoints(a.length(), -1));
+        return new TextInputContext(active, State.immutable(ns), State.immutable(na), reset);
+    }
+
     public @NotNull TextInputContext withReset(boolean reset) {
         return new TextInputContext(active, stream, additional, reset);
     }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/layout/Layout.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/layout/Layout.java
@@ -181,7 +181,7 @@ public interface Layout<E extends ModernElement<E, Canvas>> extends ElementConta
         private void handleElement(@NotNull ModernElement<?, Canvas> elementLike) {
             Vec2i vecPos = PropertyHelper.vectorOrThrow(elementLike.position(), Vec2i.class);
             Vec2i layoutVecPos = PropertyHelper.vectorOrThrow(position(), Vec2i.class);
-            elementLike.position(Position.fixed(vecPos.add(layoutVecPos)));
+            elementLike.position(Position.fixed(vecPos.add(layoutVecPos)).target(elementLike.position().target()));
             if (!(elementLike instanceof GenericInteractableModernElement<?,?,?> interactableModernElement)) return;
             interactableModernElement.inputHandler(handler);
         }
@@ -261,9 +261,11 @@ public interface Layout<E extends ModernElement<E, Canvas>> extends ElementConta
             }
             Vec2i calculatedSize = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
             Canvas finalCanvas = Canvas.empty(calculatedSize);
-            Vec2i layoutPosVec = PropertyHelper.vectorOrThrow(position(), Vec2i.class);
+            Vec2i layoutSizeVec = PropertyHelper.vectorOrThrow(size(), Vec2i.class);
+            Vec2i layoutPosVec = position().resolve(layoutSizeVec);
             for (ModernElement<?, Canvas> value : elements.values()) {
-                Vec2i posVec = PropertyHelper.vectorOrThrow(value.position(), Vec2i.class);
+                Vec2i elementSize = PropertyHelper.vectorOrThrow(value.size(), Vec2i.class);
+                Vec2i posVec = value.position().resolve(elementSize);
                 finalCanvas.place(value.render(property, context), posVec.sub(layoutPosVec));
             }
             return finalCanvas;

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/pack/ResourcePackDownloader.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/pack/ResourcePackDownloader.java
@@ -27,7 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 public class ResourcePackDownloader {
-    private static final Path CACHE = SunscreenLibrary.library().path().resolve(".cache", "pack.zip");
+    private static final Path CACHE = SunscreenLibrary.library().path().resolve(".cache").resolve("pack.zip");
 
     public static void download(@NotNull String url) throws IOException {
         InputStream in;

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Position.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Position.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Position> implements EditorProperty<Vec2i, Position, SelectorInputContext.ValueInnerContext> {
@@ -16,6 +17,33 @@ public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Po
     private static final Position ZERO = Position.fixed(Vec2i.zero());
 
     private final Map<RelativeMeasure.Axis2d, RelativeMeasure.RelativeBuilder<Size>> axisMap = new LinkedHashMap<>();
+    private Target target = Target.TOP_LEFT;
+
+    /**
+     * Anchor on the element box: position value is the point named by the constant; {@link #resolve(Vec2i)} returns top-left
+     * by subtracting {@link #offset(Vec2i)} from that point.
+     */
+    public enum Target {
+        TOP_LEFT(s -> Vec2i.zero()),
+        TOP_CENTER(s -> Vec2i.of(s.x() / 2, 0)),
+        TOP_RIGHT(s -> Vec2i.of(s.x(), 0)),
+        LEFT_CENTER(s -> Vec2i.of(0, s.y() / 2)),
+        CENTER(s -> Vec2i.of(s.x() / 2, s.y() / 2)),
+        RIGHT_CENTER(s -> Vec2i.of(s.x(), s.y() / 2)),
+        BOTTOM_LEFT(s -> Vec2i.of(0, s.y())),
+        BOTTOM_CENTER(s -> Vec2i.of(s.x() / 2, s.y())),
+        BOTTOM_RIGHT(s -> Vec2i.of(s.x(), s.y()));
+
+        private final Function<Vec2i, Vec2i> anchorToTopLeftOffset;
+
+        Target(@NotNull Function<Vec2i, Vec2i> anchorToTopLeftOffset) {
+            this.anchorToTopLeftOffset = anchorToTopLeftOffset;
+        }
+
+        public @NotNull Vec2i offset(@NotNull Vec2i elementSize) {
+            return anchorToTopLeftOffset.apply(elementSize);
+        }
+    }
 
     public static Position nil() {
         return ZERO;
@@ -44,6 +72,20 @@ public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Po
 
     public static @NotNull Position supplied(@NotNull Supplier<Vec2i> supplier) {
         return new Position(supplier);
+    }
+
+    public @NotNull Position target(@NotNull Target target) {
+        this.target = target;
+        return this;
+    }
+
+    public @NotNull Target target() {
+        return target;
+    }
+
+    public @NotNull Vec2i resolve(@NotNull Vec2i size) {
+        Vec2i value = value();
+        return value.sub(target.offset(size));
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Visibility.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Visibility.java
@@ -26,7 +26,7 @@ public record Visibility(boolean hide) implements Property<Boolean, Visibility> 
 
     @Override
     public @NotNull PropertyHandler<Visibility> handler() {
-        return (_, _, _) -> null;
+        return (e, r, v) -> null;
     }
 
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Z.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Z.java
@@ -21,7 +21,7 @@ public record Z(float value) implements Property<Float, Z> {
 
     @Override
     public @NotNull PropertyHandler<Z> handler() {
-        return (_, _, _) -> null;
+        return (e, r, z) -> null;
     }
 
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/protocol/PlatformProtocolIntermediate.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/protocol/PlatformProtocolIntermediate.java
@@ -3,6 +3,7 @@ package me.combimagnetron.sunscreen.neo.protocol;
 import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
 import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.passport.util.math.Vec3f;
+import me.combimagnetron.sunscreen.nativeui.NativeUi;
 import me.combimagnetron.sunscreen.neo.graphic.Item;
 import me.combimagnetron.sunscreen.neo.protocol.type.EntityReference;
 import me.combimagnetron.sunscreen.neo.protocol.type.Location;
@@ -11,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 
-public interface PlatformProtocolIntermediate<I> {
+public interface PlatformProtocolIntermediate<I> extends NativeUi {
 
     EntityReference<?> spawnAndRideHorse(@NotNull SunscreenUser<?> user, @NotNull Location location);
 

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/registry/Registries.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/registry/Registries.java
@@ -11,32 +11,32 @@ import me.combimagnetron.sunscreen.util.IdentifierHolder;
 import org.jetbrains.annotations.NotNull;
 
 public interface Registries {
-    Registry<CursorStyle> CURSOR_STYLES = Registry.empty();
-    Registry<MenuTemplate> TEMPLATES = Registry.empty();
-    Registry<ModernTheme> THEMES = Registry.empty();
-    Registry<AtlasFont> FONTS = Registry.empty();
-    Registry<ElementConstructionProvider<?>> CONSTRUCTION_PROVIDERS = Registry.empty();
+    Registry<CursorStyle, Identifier> CURSOR_STYLES = Registry.identifier();
+    Registry<MenuTemplate, Identifier> TEMPLATES = Registry.identifier();
+    Registry<ModernTheme, Identifier> THEMES = Registry.identifier();
+    Registry<AtlasFont, Identifier> FONTS = Registry.identifier();
+    Registry<ElementConstructionProvider<?>, Identifier> CONSTRUCTION_PROVIDERS = Registry.identifier();
 
-    static <T extends IdentifierHolder> boolean register(@NotNull Registry<T> registry, @NotNull T t) {
+    static <T extends IdentifierHolder> boolean register(@NotNull Registry<T, Identifier> registry, @NotNull T t) {
         Identifier identifier = t.identifier();
         if (registry.contains(identifier)) return false;
         registry.register(identifier, t);
         return true;
     }
 
-    static @NotNull Registry<ElementConstructionProvider<?>> constructionProviders() {
+    static @NotNull Registry<ElementConstructionProvider<?>, Identifier> constructionProviders() {
         return CONSTRUCTION_PROVIDERS;
     }
 
-    static @NotNull Registry<MenuTemplate> templates() {
+    static @NotNull Registry<MenuTemplate, Identifier> templates() {
         return TEMPLATES;
     }
 
-    static @NotNull Registry<ModernTheme> themes() {
+    static @NotNull Registry<ModernTheme, Identifier> themes() {
         return THEMES;
     }
 
-    static @NotNull Registry<AtlasFont> fonts() {
+    static @NotNull Registry<AtlasFont, Identifier> fonts() {
         return FONTS;
     }
 

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/render/engine/phase/RenderPhase.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/render/engine/phase/RenderPhase.java
@@ -8,6 +8,7 @@ import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
 import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.passport.util.math.Vec3f;
 import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.nativeui.ClientRasterTile;
 import me.combimagnetron.sunscreen.neo.element.ModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.BufferedColorSpace;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
@@ -67,7 +68,7 @@ public interface RenderPhase<N extends RenderPhase<? extends RenderPhase<?>>> {
                     if (group.value() != null) continue;
                     group.finish(user.screenInfo().viewport());
                 }
-                List<ModernElement<?, ?>> list = elementsByScale.computeIfAbsent(new Meta(scale, z.value()), (_) -> new ArrayList<>());
+                List<ModernElement<?, ?>> list = elementsByScale.computeIfAbsent(new Meta(scale, z.value()), (r) -> new ArrayList<>());
                 list.add(modernElement);
             }
         }
@@ -129,27 +130,34 @@ public interface RenderPhase<N extends RenderPhase<? extends RenderPhase<?>>> {
                 BigDecimal scale = meta.bigDecimal();
                 Vec2i viewportVec = viewport.currentView();
                 Vec2i canvasSize = Vec2i.of((viewportVec.x() + 127) & ~127, (viewportVec.y() + 127) & ~127);
-                canvasses.computeIfAbsent(meta, _ -> Canvas.empty(canvasSize));
+                canvasses.computeIfAbsent(meta, m -> Canvas.empty(canvasSize));
                 for (ModernElement<?, ?> elementLike : entry.getValue()) {
                     if (!(elementLike instanceof ModernElement<?, ?> element)) continue;
-                    Vec2i positionVec = PropertyHelper.vectorOrThrow(elementLike.position(), Vec2i.class);
                     GraphicLike<?> graphics = element.render(Size.fixed(canvasSize), renderContext);
-                    switch (graphics) {
-                        case Canvas toPlace -> canvasses.computeIfPresent(meta,
-                            (_, canvas) -> canvas.place(toPlace.bufferedColorSpace(), positionVec));
-                        case Item<?> item -> {
-                            RenderCache cache = renderContext.renderCache();
-                            Vec3f gridPos = vec3f(item);
-                            Integer id = cache.byPosAndScale(scale, gridPos);
-                            boolean exists = id != null;
-                            Rotation rotation = element.rotation();
-                            item = item.transform(item.transformation().rotationLeft(rotation.quaternion()).scale(Vector3d.vec3(scale.floatValue())));
-                            if (!exists) {
-                                cache.next(new ItemRenderChunk(null, gridPos, scale, item.hashCode()));
-                                SunscreenLibrary.library().intermediate().spawnItemDisplay(user, new Location(user.eyeLocation().x(), user.eyeLocation().y() - 1, user.eyeLocation().z()), (Item<Object>) item, positionVec);
+                    if (user.useNativeUi()) {
+                        Vec2i elementSize = PropertyHelper.vectorOrThrow(elementLike.size(), Vec2i.class);
+                        Vec2i positionVec = elementLike.position().resolve(elementSize);
+                        canvasses.computeIfPresent(meta,
+                            (m, canvas) -> canvas.place(graphics.bufferedColorSpace(), positionVec));
+                    } else {
+                        Vec2i positionVec = PropertyHelper.vectorOrThrow(elementLike.position(), Vec2i.class);
+                        switch (graphics) {
+                            case Canvas toPlace -> canvasses.computeIfPresent(meta,
+                                (m, canvas) -> canvas.place(toPlace.bufferedColorSpace(), positionVec));
+                            case Item<?> item -> {
+                                RenderCache cache = renderContext.renderCache();
+                                Vec3f gridPos = vec3f(item);
+                                Integer id = cache.byPosAndScale(scale, gridPos);
+                                boolean exists = id != null;
+                                Rotation rotation = element.rotation();
+                                item = item.transform(item.transformation().rotationLeft(rotation.quaternion()).scale(Vector3d.vec3(scale.floatValue())));
+                                if (!exists) {
+                                    cache.next(new ItemRenderChunk(null, gridPos, scale, item.hashCode()));
+                                    SunscreenLibrary.library().intermediate().spawnItemDisplay(user, new Location(user.eyeLocation().x(), user.eyeLocation().y() - 1, user.eyeLocation().z()), (Item<Object>) item, positionVec);
+                                }
                             }
+                            default -> {}
                         }
-                        default -> {}
                     }
                 }
             }
@@ -278,20 +286,42 @@ public interface RenderPhase<N extends RenderPhase<? extends RenderPhase<?>>> {
             RenderCache renderCache = renderContext.renderCache();
             PlatformProtocolIntermediate intermediate = SunscreenLibrary.library().intermediate();
             final Location location = user.eyeLocation();
-            intermediate.bundleDelimiter(user);
-            for (Integer i : renderContext.markedForRemoval()) {
-                renderContext.renderCache().remove(i, user);
+            if (!user.useNativeUi()) {
+                intermediate.bundleDelimiter(user);
             }
-            for (EncodedRenderChunk chunk : chunks) {
-                Integer mapId = renderCache.byPosAndScale(chunk.scale(), chunk.position());
-                if (mapId == null) {
-                    mapId = renderCache.next(chunk);
-                    intermediate.spawnAndFillItemFrame(user, location, chunk.data(), mapId);
+            for (Integer i : renderContext.markedForRemoval()) {
+                if (user.useNativeUi()) {
+                    renderCache.remove(i);
                 } else {
-                    intermediate.updateMap(user, mapId, chunk.data());
+                    renderCache.remove(i, user);
                 }
             }
-            intermediate.bundleDelimiter(user);
+            if (user.useNativeUi()) {
+                List<ClientRasterTile> tiles = new ArrayList<>();
+                for (EncodedRenderChunk chunk : chunks) {
+                    var bcs = chunk.bufferedColorSpace();
+                    int[] src = bcs.buffer();
+                    tiles.add(new ClientRasterTile(chunk.scale(), chunk.position(), bcs.size().x(), bcs.size().y(), src));
+                    Integer mapId = renderCache.byPosAndScale(chunk.scale(), chunk.position());
+                    if (mapId == null) {
+                        renderCache.next(chunk);
+                    }
+                }
+                intermediate.serverSendTiles(user, tiles);
+            } else {
+                for (EncodedRenderChunk chunk : chunks) {
+                    Integer mapId = renderCache.byPosAndScale(chunk.scale(), chunk.position());
+                    if (mapId == null) {
+                        mapId = renderCache.next(chunk);
+                        intermediate.spawnAndFillItemFrame(user, location, chunk.data(), mapId);
+                    } else {
+                        intermediate.updateMap(user, mapId, chunk.data());
+                    }
+                }
+            }
+            if (!user.useNativeUi()) {
+                intermediate.bundleDelimiter(user);
+            }
             renderContext.markedForRemoval().clear();
             return Pair.of(new Empty(), renderContext);
         }

--- a/api/src/main/java/me/combimagnetron/sunscreen/user/SunscreenUser.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/user/SunscreenUser.java
@@ -19,4 +19,9 @@ public interface SunscreenUser<T extends Audience> extends User<T> {
 
     @NotNull Location eyeLocation();
 
+    boolean useNativeUi();
+
+    default void setNativeUi(boolean enabled) {
+    }
+
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/util/FileProvider.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/util/FileProvider.java
@@ -2,9 +2,12 @@ package me.combimagnetron.sunscreen.util;
 
 import me.combimagnetron.sunscreen.SunscreenLibrary;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.util.Objects;
 
 public interface FileProvider {
 
@@ -28,12 +31,31 @@ public interface FileProvider {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            try(OutputStream out = new FileOutputStream(file)){
-                IOUtils.copy(SunscreenLibrary.library().resource(path), out);
+            try (InputStream in = openClasspathResource(path);
+                 OutputStream out = new FileOutputStream(file)) {
+                IOUtils.copy(Objects.requireNonNull(in, "Missing classpath resource: " + path), out);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
             return file;
+        }
+
+        private static @Nullable InputStream openClasspathResource(@NotNull String path) {
+            SunscreenLibrary<?, ?, ?> lib = SunscreenLibrary.library();
+            if (lib != null) {
+                InputStream fromLib = lib.resource(path);
+                if (fromLib != null) {
+                    return fromLib;
+                }
+            }
+            ClassLoader ctx = Thread.currentThread().getContextClassLoader();
+            if (ctx != null) {
+                InputStream in = ctx.getResourceAsStream(path);
+                if (in != null) {
+                    return in;
+                }
+            }
+            return SunscreenLibrary.class.getClassLoader().getResourceAsStream(path);
         }
 
     }

--- a/api/src/main/java/me/combimagnetron/sunscreen/util/helper/ElementSizeSeeder.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/util/helper/ElementSizeSeeder.java
@@ -1,0 +1,137 @@
+package me.combimagnetron.sunscreen.util.helper;
+
+import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.neo.element.ElementContainer;
+import me.combimagnetron.sunscreen.neo.element.ElementLike;
+import me.combimagnetron.sunscreen.neo.element.GenericInteractableModernElement;
+import me.combimagnetron.sunscreen.neo.element.ModernElement;
+import me.combimagnetron.sunscreen.neo.graphic.Canvas;
+import me.combimagnetron.sunscreen.neo.graphic.NineSlice;
+import me.combimagnetron.sunscreen.neo.property.Decorator;
+import me.combimagnetron.sunscreen.neo.property.Size;
+import me.combimagnetron.sunscreen.neo.theme.ModernTheme;
+import me.combimagnetron.sunscreen.neo.theme.decorator.ThemeDecorator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * Fills missing {@link Size} from element content ({@link ModernElement#intrinsicSize()}) and, when a
+ * {@link ModernTheme} is present, from themed nine-slice <strong>source</strong> canvases.
+ * <p>
+ * Call only via {@link #seedMenuTree(Collection, ModernTheme)} after the menu tree is fully built (or for roots
+ * passed to {@link me.combimagnetron.sunscreen.neo.ActiveMenu#add}).
+ */
+public final class ElementSizeSeeder {
+
+    private ElementSizeSeeder() {}
+
+    /**
+     * Runs intrinsic sizing for every node under {@code roots}, then a theme pass for any size still missing.
+     */
+    public static void seedMenuTree(@NotNull Collection<ElementLike<?>> roots, @Nullable ModernTheme theme) {
+        for (ElementLike<?> root : roots) {
+            seedRecursive(root);
+        }
+        seedFromTheme(roots, theme);
+    }
+
+    private static void seedRecursive(@NotNull ElementLike<?> elementLike) {
+        if (elementLike instanceof ElementContainer<?> container) {
+            for (ModernElement<?, Canvas> child : container.children()) {
+                seedRecursive(child);
+            }
+        }
+        if (elementLike instanceof ModernElement<?, ?> modern) {
+            seedElement(modern);
+        }
+    }
+
+    private static void seedFromTheme(@NotNull Collection<ElementLike<?>> roots, @Nullable ModernTheme theme) {
+        if (theme == null) return;
+        for (ElementLike<?> root : roots) {
+            seedFromThemeRecursive(root, theme);
+        }
+    }
+
+    private static void seedFromThemeRecursive(@NotNull ElementLike<?> elementLike, @NotNull ModernTheme theme) {
+        if (elementLike instanceof ElementContainer<?> container) {
+            for (ModernElement<?, Canvas> child : container.children()) {
+                seedFromThemeRecursive(child, theme);
+            }
+        }
+        if (elementLike instanceof ModernElement<?, ?> modern) {
+            seedElementFromTheme(modern, theme);
+        }
+    }
+
+    private static void seedElementFromTheme(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        if (!needsIntrinsicSeed(element.property(Size.class))) return;
+        Vec2i fromTheme = sizeFromResolvedThemeDecorator(element, theme);
+        if (fromTheme != null) element.size(Size.fixed(fromTheme));
+    }
+
+    private static void seedElement(@NotNull ModernElement<?, ?> element) {
+        Size sizeProp = element.property(Size.class);
+        if (!needsIntrinsicSeed(sizeProp)) return;
+        Vec2i intrinsic = element.intrinsicSize();
+        if (intrinsic == null) return;
+        element.size(Size.fixed(intrinsic));
+    }
+
+    /**
+     * @return true if we should assign a fixed intrinsic size before layout / render.
+     */
+    private static boolean needsIntrinsicSeed(@Nullable Size sizeProp) {
+        if (sizeProp == null) return true;
+        if (sizeProp instanceof Size.Fit) return true;
+        if (sizeProp.value() != null) return false;
+        // Unresolved relative size: resolved from viewport in the render pipeline.
+        return sizeProp.axisBuilderMap().isEmpty();
+    }
+
+    /**
+     * Mirrors {@code RenderContext.decorator} target resolution, then reads intrinsic size from nine-slice source art.
+     */
+    private static @Nullable Vec2i sizeFromResolvedThemeDecorator(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        ThemeDecorator decorator = resolveThemeDecorator(element, theme);
+        return sizeFromThemeDecorator(decorator);
+    }
+
+    private static @Nullable ThemeDecorator resolveThemeDecorator(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        Decorator<?> dec = element.property(Decorator.class);
+        if (dec == null || dec.target().target().equals(element.getClass())) {
+            for (ThemeDecorator candidate : theme.decorators()) {
+                if (candidate.target().target().equals(element.getClass())) return candidate;
+            }
+            return null;
+        }
+        return theme.find(dec.target());
+    }
+
+    private static @Nullable Vec2i sizeFromThemeDecorator(@Nullable ThemeDecorator decorator) {
+        if (decorator == null) return null;
+        if (decorator instanceof ThemeDecorator.StateNineSliceThemeDecorator stated) {
+            return firstNineSliceSourceSize(stated);
+        }
+        if (decorator instanceof ThemeDecorator.NineSliceThemeDecorator simple) {
+            return simple.nineSlice().sourceCanvas().size();
+        }
+        return null;
+    }
+
+    private static @Nullable Vec2i firstNineSliceSourceSize(@NotNull ThemeDecorator.StateNineSliceThemeDecorator stated) {
+        NineSlice slice = stated.nineSlices().get(GenericInteractableModernElement.ElementPhase.DEFAULT);
+        if (slice == null) {
+            for (NineSlice candidate : stated.nineSlices().values()) {
+                if (candidate != null) {
+                    slice = candidate;
+                    break;
+                }
+            }
+        }
+        return slice == null ? null : slice.sourceCanvas().size();
+    }
+
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/util/helper/HoverHelper.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/util/helper/HoverHelper.java
@@ -14,9 +14,9 @@ public class HoverHelper {
     public static <E extends ElementLike<E>> boolean in(@NotNull ElementLike<E> elementLike, @NotNull Vec2i cursor) {
         final Position position = elementLike.propOrThrow(Position.class);
         final Size size = elementLike.propOrThrow(Size.class);
-        Vec2i vecPosition = position.value();
         Vec2i vecSize = size.value();
-        if (vecPosition == null || vecSize == null) return false;
+        if (position.value() == null || vecSize == null) return false;
+        Vec2i vecPosition = position.resolve(vecSize);
         return in(vecPosition, vecSize, cursor);
     }
 
@@ -29,7 +29,12 @@ public class HoverHelper {
     public static <E extends ElementLike<E>> boolean in(@NotNull ElementLike<E> elementLike, @NotNull Viewport viewport) {
         Vec2i vecPosition = viewport.position();
         Vec2i vecSize = viewport.currentView();
-        Vec2i elementPosition = elementLike.propOrThrow(Position.class).value();
+        Position position = elementLike.propOrThrow(Position.class);
+        Size size = elementLike.propOrThrow(Size.class);
+        Vec2i elementSize = size.value();
+        Vec2i anchor = position.value();
+        if (elementSize == null || anchor == null) return false;
+        Vec2i elementPosition = position.resolve(elementSize);
         boolean xCheck = (elementPosition.x() >= vecPosition.x() && elementPosition.x() <= vecPosition.x() + vecSize.x());
         boolean yCheck = (elementPosition.y() >= vecPosition.y() && elementPosition.y() <= vecPosition.y() + vecSize.y());
         return xCheck && yCheck;

--- a/build-system/build.gradle.kts
+++ b/build-system/build.gradle.kts
@@ -24,5 +24,5 @@ tasks.test {
     useJUnitPlatform()
 }
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(21)
 }

--- a/build-system/src/main/kotlin/sunscreen-main.gradle.kts
+++ b/build-system/src/main/kotlin/sunscreen-main.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
     `java-library`
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,0 +1,142 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.loom.task.RemapJarTask
+import java.nio.file.Files
+import java.nio.file.Path
+
+plugins {
+    id("java")
+    id("net.fabricmc.fabric-loom-remap") version "1.16-SNAPSHOT"
+    id("com.gradleup.shadow") version "9.2.2"
+    id("sunscreen-publish")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+val minecraftVersion = libs.versions.minecraft.get()
+val fabricModulesByMinecraft = mapOf(
+    "1.21.1" to "0.116.10",
+    "1.21.11" to "0.140.2"
+)
+val fabricModules = fabricModulesByMinecraft[minecraftVersion]
+    ?: error("Unsupported minecraft version for split Fabric modules: $minecraftVersion")
+
+repositories {
+    maven("https://maven.fabricmc.net/")
+    mavenCentral()
+}
+
+configurations.configureEach {
+    if (name.endsWith("runtimeClasspath", ignoreCase = true)) {
+        // Minecraft pulls org.lz4 while :api pulls at.yawk.lz4; keep only one provider.
+        exclude(group = "org.lz4", module = "lz4-java")
+    }
+}
+
+loom {
+    splitEnvironmentSourceSets()
+    accessWidenerPath.set(file("src/main/resources/sunscreen.accesswidener"))
+
+    mods {
+        create("sunscreen") {
+            sourceSet(sourceSets["main"])
+            sourceSet(sourceSets["client"])
+        }
+    }
+
+    runs {
+        named("client") {
+            client()
+            ideConfigGenerated(true)
+            runDir("run/client")
+            programArgs("--username", "TestUser")
+            vmArgs(
+                "-XX:+AllowEnhancedClassRedefinition",
+                "-javaagent:\"C:\\Users\\Justin\\.gradle\\caches\\modules-2\\files-2.1\\net.fabricmc\\sponge-mixin\\0.17.0+mixin.0.8.7\\cf31463202f72d03b0ef1e1e38e8ee71b7faaab6\\sponge-mixin-0.17.0+mixin.0.8.7.jar\""
+            )
+        }
+        named("server") {
+            server()
+            configName = "Run Fabric Server"
+            ideConfigGenerated(true)
+            runDir("run/server")
+            vmArgs(
+                "-XX:+AllowEnhancedClassRedefinition",
+                "-javaagent:\"C:\\Users\\Justin\\.gradle\\caches\\modules-2\\files-2.1\\net.fabricmc\\sponge-mixin\\0.17.0+mixin.0.8.7\\cf31463202f72d03b0ef1e1e38e8ee71b7faaab6\\sponge-mixin-0.17.0+mixin.0.8.7.jar\""
+            )
+        }
+    }
+}
+
+dependencies {
+    minecraft("com.mojang:minecraft:${minecraftVersion}")
+    mappings(loom.officialMojangMappings())
+    modImplementation(libs.fabric.loader)
+    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricModules+$minecraftVersion")
+    compileOnly("systems.manifold:manifold-preprocessor:+")
+    annotationProcessor("systems.manifold:manifold-preprocessor:+")
+
+    implementation(project(":api"))
+    implementation(project(":common"))
+
+    implementation("net.kyori:adventure-api:4.25.0")
+}
+
+val manifoldMcFlag = when (minecraftVersion) {
+    "1.21.1" -> "MC_1_21_1"
+    "1.21.11" -> "MC_1_21_11"
+    else -> error("Unsupported minecraft version for Manifold preprocessors: $minecraftVersion")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.addAll(
+        listOf(
+            "-Xplugin:Manifold",
+            "-Amanifold.source.files=.java",
+            "-A$manifoldMcFlag"
+        )
+    )
+}
+
+val shadowJar = tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("shaded")
+    // Loom split environments keep client classes/configuration separate.
+    from(sourceSets["main"].output)
+    from(sourceSets["client"].output)
+    configurations = listOf(
+        project.configurations.runtimeClasspath.get(),
+        project.configurations.getByName("clientRuntimeClasspath")
+    )
+    mergeServiceFiles()
+    relocate("net.jpountz.lz4", "me.combimagnetron.sunscreen.shaded.net.jpountz.lz4")
+    dependencies {
+        exclude {
+            var g = it.moduleGroup
+            g != "net.kyori" && g != "me.combimagnetron" && g != "io.github.revxrsal" && g != "team.unnamed" && g != "at.yawk.lz4"
+        }
+    }
+}
+
+tasks.named<RemapJarTask>("remapJar") {
+    dependsOn(shadowJar)
+    inputFile.set(shadowJar.get().archiveFile)
+}
+
+tasks.processResources {
+    val version = project.version.toString()
+    inputs.property("version", version)
+    inputs.property("minecraftVersion", minecraftVersion)
+    inputs.property("fabricModules", fabricModules)
+    filesMatching("fabric.mod.json") {
+        expand(
+            mapOf(
+                "version" to version,
+                "minecraftVersion" to minecraftVersion,
+                "fabricModules" to fabricModules
+            )
+        )
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/FabricNativeUiClientNetworking.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/FabricNativeUiClientNetworking.java
@@ -1,0 +1,47 @@
+package me.combimagnetron.sunscreen.fabric.client;
+
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.fabric.nativeui.FabricNativeUiNetworking;
+import me.combimagnetron.sunscreen.fabric.nativeui.NativeUiChunkS2CPayload;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricPlatformProtocolIntermediate;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client-side receiver for the unified native-UI chunk channel, C2S sink binding, and join handshake.
+ */
+public final class FabricNativeUiClientNetworking {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sunscreen/NativeUi");
+
+    private FabricNativeUiClientNetworking() {
+    }
+
+    public static void register() {
+        FabricNativeUiNetworking.registerPayloadTypes();
+
+        FabricPlatformProtocolIntermediate.setSender(ClientPlayNetworking::send);
+
+        ClientPlayNetworking.registerGlobalReceiver(
+            NativeUiChunkS2CPayload.TYPE,
+            (payload, context) ->
+                NativeMenuRasterReceiver.onTransportChunk(
+                    payload.data()
+                )
+        );
+
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> NativeMenuRasterReceiver.resetAll());
+
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+            NativeMenuRasterReceiver.resetAll();
+            var lib = SunscreenLibrary.library();
+            if (lib == null) {
+                LOGGER.warn("SunscreenLibraryFabric not initialised; native UI C2S will not send until common mod loads.");
+                return;
+            }
+            lib.intermediate().clientHandshake(true);
+            LOGGER.debug("Sent Sunscreen native UI support announce (one-way).");
+        });
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/NativeMenuRasterReceiver.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/NativeMenuRasterReceiver.java
@@ -1,0 +1,78 @@
+package me.combimagnetron.sunscreen.fabric.client;
+
+import me.combimagnetron.sunscreen.fabric.client.nativeui.ServerRasterMenuScreen;
+import me.combimagnetron.sunscreen.nativeui.MenuRasterWireCodec;
+import me.combimagnetron.sunscreen.nativeui.NativeUi;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Dispatches native-UI S2C: single-chunk messages bypass multi-chunk reassembly so they never interrupt a raster stream.
+ */
+public final class NativeMenuRasterReceiver {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sunscreen/NativeUi");
+    private static volatile @Nullable String activeMenuId;
+    private static volatile ByteBuffer currentRaster = null;
+
+    private NativeMenuRasterReceiver() {
+    }
+
+    public static void onTransportChunk(byte @NotNull [] packetBytes) {
+        ByteBuffer logical = NativeUi.receiveClientS2CPacket(packetBytes);
+        if (logical == null) {
+            return;
+        }
+        dispatchLogical(logical);
+    }
+
+    private static void dispatchLogical(@NotNull ByteBuffer logical) {
+        switch (NativeUi.decodeClientS2C(logical)) {
+            case NativeUi.S2CLogical.Close() -> Minecraft.getInstance().execute(() -> {
+                NativeMenuRasterReceiver.resetAll();
+                if (Minecraft.getInstance().screen instanceof ServerRasterMenuScreen) {
+                    Minecraft.getInstance().setScreen(null);
+                }
+            });
+            case NativeUi.S2CLogical.Raster(String menuId, ByteBuffer rasterWire) -> onRasterPayload(menuId, rasterWire);
+            case NativeUi.S2CLogical.Unknown() -> LOGGER.warn("Unknown native UI S2C logical frame.");
+        }
+    }
+
+    private static void onRasterPayload(@NotNull String menuId, @NotNull ByteBuffer rasterWire) {
+        ensureActiveMenu(menuId);
+        currentRaster = rasterWire.slice();
+        try {
+            var frame = MenuRasterWireCodec.decoder().readFrame(currentRaster);
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.screen instanceof ServerRasterMenuScreen scr && scr.menuId().equals(menuId)) {
+                scr.ingestRasterFrame(frame);
+            } else {
+                mc.setScreen(new ServerRasterMenuScreen(menuId));
+                if (mc.screen instanceof ServerRasterMenuScreen scr2) {
+                    scr2.ingestRasterFrame(frame);
+                }
+            }
+            currentRaster = null;
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to decode native menu raster for {}", menuId, e);
+        }
+    }
+
+    private static synchronized void ensureActiveMenu(@NotNull String menuId) {
+        if (menuId.equals(activeMenuId)) {
+            return;
+        }
+        activeMenuId = menuId;
+    }
+
+    public static synchronized void resetAll() {
+        activeMenuId = null;
+        currentRaster = null;
+        NativeUi.resetClientS2CReassembly();
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/SunscreenFabricClientMod.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/SunscreenFabricClientMod.java
@@ -1,0 +1,12 @@
+package me.combimagnetron.sunscreen.fabric.client;
+
+import me.combimagnetron.sunscreen.fabric.nativeui.FabricNativeUiNetworking;
+import net.fabricmc.api.ClientModInitializer;
+
+public final class SunscreenFabricClientMod implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        FabricNativeUiNetworking.registerPayloadTypes();
+        FabricNativeUiClientNetworking.register();
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/DirectGlRgbTexture.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/DirectGlRgbTexture.java
@@ -1,0 +1,153 @@
+package me.combimagnetron.sunscreen.fabric.client.nativeui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.nativeui.ClientRasterTile;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import org.jetbrains.annotations.NotNull;
+import com.mojang.blaze3d.platform.NativeImage;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.util.List;
+
+/**
+ * RGBA8 storage in a direct {@link ByteBuffer}, uploaded into a Minecraft-managed dynamic texture.
+ */
+public final class DirectGlRgbTexture implements AutoCloseable {
+    private final int width;
+    private final int height;
+    private final ByteBuffer byteBuffer;
+    private final IntBuffer intView;
+    private final NativeImage image;
+    private final DynamicTexture texture;
+    private final Object textureId;
+    private boolean needsUpload;
+    /** Reused row buffer for ARGB→ABGR conversion + {@link IntBuffer#put(int, int[], int, int)} bulk store. */
+    private int[] rowScratch = new int[128];
+
+    public DirectGlRgbTexture(int width, int height) {
+        this.width = width;
+        this.height = height;
+        this.byteBuffer = ByteBuffer
+                .allocateDirect(width * height * 4)
+                .order(ByteOrder.nativeOrder());
+        this.intView = byteBuffer.asIntBuffer();
+        int n = width * height;
+        for (int i = 0; i < n; i++) {
+            intView.put(i, 0);
+        }
+        var l = MemoryUtil.memAddress(this.byteBuffer);
+        this.image = new NativeImage(NativeImage.Format.RGBA, width, height, false, l);
+        this.image.untrack();
+        this.texture = RenderMappingCompat.newDynamicTexture("sunscreen/nativeui", this.image);
+        this.textureId = FabricMappingCompat.parse("sunscreen:nativeui");
+        RenderMappingCompat.register(this.textureId, this.texture);
+        this.needsUpload = true;
+    }
+
+    public int width() {
+        return width;
+    }
+
+    public int height() {
+        return height;
+    }
+
+    /**
+     * Composites the given tiles into the CPU buffer. Tiles not included are left unchanged so the
+     * server can send incremental (dirty) updates.
+     */
+    public void composeTiles(@NotNull List<ClientRasterTile> tiles) {
+        for (ClientRasterTile tile : tiles) {
+            int cx = Math.round(2.62f - tile.gridPosition().x());
+            int cy = Math.round(1.265f - tile.gridPosition().y());
+            int baseX = cx * 128;
+            int baseY = cy * 128;
+            int[] px = tile.argbPixels();
+            int tw = tile.width();
+            int th = tile.height();
+            int expected = tw * th;
+            if (px.length < expected) {
+                continue;
+            }
+            int xStart = Math.max(0, baseX);
+            int xEnd = Math.min(width, baseX + tw);
+            int rowLen = xEnd - xStart;
+            if (rowLen <= 0) {
+                continue;
+            }
+            int yStart = Math.max(0, baseY);
+            int yEnd = Math.min(height, baseY + th);
+            if (yStart >= yEnd) {
+                continue;
+            }
+            ensureRowScratch(rowLen);
+            int txStart = xStart - baseX;
+            for (int gy = yStart; gy < yEnd; gy++) {
+                int ty = gy - baseY;
+                int srcOffset = ty * tw + txStart;
+                int dstOffset = xStart + gy * width;
+                for (int i = 0; i < rowLen; i++) {
+                    rowScratch[i] = argbToAbgr(px[srcOffset + i]);
+                }
+                intView.put(dstOffset, rowScratch, 0, rowLen);
+            }
+        }
+        upload();
+    }
+
+    private static int argbToAbgr(int argb) {
+        return (argb & 0xFF00FF00) | ((argb & 0xFF) << 16) | ((argb >>> 16) & 0xFF);
+    }
+
+    private void ensureRowScratch(int rowLen) {
+        if (rowScratch.length < rowLen) {
+            rowScratch = new int[rowLen];
+        }
+    }
+
+    public void upload() {
+        if (!RenderSystem.isOnRenderThread()) {
+            needsUpload = true;
+            return;
+        }
+        uploadNow();
+    }
+
+    private void uploadNow() {
+        texture.upload();
+        needsUpload = false;
+    }
+
+    public void draw(@NotNull GuiGraphics graphics, int ox, int oy, int drawW, int drawH, float uMax, float vMax) {
+        RenderSystem.assertOnRenderThread();
+        if (needsUpload) uploadNow();
+        int srcW = Math.max(1, Math.min(width, Math.round(width * uMax)));
+        int srcH = Math.max(1, Math.min(height, Math.round(height * vMax)));
+        RenderMappingCompat.blit(
+            graphics,
+            textureId,
+            ox,
+            oy,
+            0.0f,
+            0.0f,
+            drawW,
+            drawH,
+            srcW,
+            srcH,
+            width,
+            height
+        );
+    }
+
+    @Override
+    public void close() {
+        // Can't let NativeImage dealloc our GC managed ByteBuffer
+        image.pixels = 0;
+        RenderMappingCompat.release(textureId);
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/RenderMappingCompat.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/RenderMappingCompat.java
@@ -1,0 +1,98 @@
+package me.combimagnetron.sunscreen.fabric.client.nativeui;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+#if MC_1_21_1
+import net.minecraft.resources.ResourceLocation;
+import com.mojang.blaze3d.systems.RenderSystem;
+#elif MC_1_21_11
+import net.minecraft.resources.Identifier;
+import net.minecraft.client.renderer.RenderPipelines;
+import java.util.function.Supplier;
+#endif
+import net.minecraft.client.renderer.texture.DynamicTexture;
+
+
+public final class RenderMappingCompat {
+
+    private RenderMappingCompat() {
+    }
+
+    public static void blit(
+        GuiGraphics graphics,
+        Object textureId,
+        int ox,
+        int oy,
+        float u,
+        float v,
+        int drawW,
+        int drawH,
+        int srcW,
+        int srcH,
+        int texW,
+        int texH
+    ) {
+        #if MC_1_21_1
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        graphics.blit(
+            (ResourceLocation) textureId,
+            ox,
+            oy,
+            drawW,
+            drawH,
+            u,
+            v,
+            srcW,
+            srcH,
+            texW,
+            texH
+        );
+        RenderSystem.disableBlend();
+        #elif MC_1_21_11
+        graphics.blit(
+             RenderPipelines.GUI_TEXTURED,
+            (Identifier) textureId,
+            ox,
+            oy,
+            u,
+            v,
+            drawW,
+            drawH,
+            srcW,
+            srcH,
+            texW,
+            texH
+        );
+        #endif
+    }
+
+    public static DynamicTexture newDynamicTexture(String prefix, NativeImage image) {
+        #if MC_1_21_1
+        return new DynamicTexture(image);
+        #elif MC_1_21_11
+        return new DynamicTexture((Supplier<String>) () -> prefix, image);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static void register(Object key, DynamicTexture texture) {
+        var manager = Minecraft.getInstance().getTextureManager();
+        #if MC_1_21_1
+        manager.register((ResourceLocation) key, texture);
+        #elif MC_1_21_11
+        manager.register((Identifier) key, texture);
+        #endif
+    }
+
+    public static void release(Object key) {
+        var manager = Minecraft.getInstance().getTextureManager();
+        #if MC_1_21_1
+        manager.release((ResourceLocation) key);
+        #elif MC_1_21_11
+        manager.release((Identifier) key);
+        #endif
+    }
+}

--- a/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/ServerRasterMenuScreen.java
+++ b/fabric/src/client/java/me/combimagnetron/sunscreen/fabric/client/nativeui/ServerRasterMenuScreen.java
@@ -1,0 +1,281 @@
+package me.combimagnetron.sunscreen.fabric.client.nativeui;
+
+import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.fabric.client.NativeMenuRasterReceiver;
+import me.combimagnetron.sunscreen.nativeui.MenuRasterWireCodec;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenKeyboardEvents;
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.glfw.GLFW;
+
+import static org.lwjgl.glfw.GLFW.glfwGetClipboardString;
+
+// Resist the urge to rename to SunScreen
+public final class ServerRasterMenuScreen extends Screen {
+    private final String menuId;
+    private @Nullable DirectGlRgbTexture canvas;
+    private int logicalWidth;
+    private int logicalHeight;
+    private int rasterWidth;
+    private int rasterHeight;
+    private long lastMoveSendMs;
+
+    private boolean leftClicked;
+    private boolean rightClicked;
+
+    public ServerRasterMenuScreen(@NotNull String menuId) {
+        super(Component.literal("Sunscreen: " + menuId));
+        this.menuId = menuId;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        // Screen init runs again after window resize; re-register per-screen input hooks so
+        // mouse press/release forwarding (used by drags) remains active.
+        registerInputHooks();
+    }
+
+    public @NotNull String menuId() {
+        return menuId;
+    }
+
+    public void ingestRasterFrame(@NotNull MenuRasterWireCodec.DecodedFrame frame) {
+        logicalWidth = frame.logicalWidth();
+        logicalHeight = frame.logicalHeight();
+        rasterWidth = (logicalWidth + 127) & ~127;
+        rasterHeight = (logicalHeight + 127) & ~127;
+        boolean resized = canvas == null
+            || canvas.width() != rasterWidth
+            || canvas.height() != rasterHeight;
+        if (resized) {
+            if (canvas != null) {
+                canvas.close();
+            }
+            canvas = new DirectGlRgbTexture(rasterWidth, rasterHeight);
+        }
+        canvas.composeTiles(frame.tiles());
+    }
+
+    private @NotNull Vec2i toLogical(double mouseX, double mouseY) {
+        if (logicalWidth <= 0 || logicalHeight <= 0) {
+            return Vec2i.zero();
+        }
+        float scale = Math.min(
+            (float) width / logicalWidth,
+            (float) height / logicalHeight
+        );
+        int drawW = Math.round(logicalWidth * scale);
+        int drawH = Math.round(logicalHeight * scale);
+        int ox = (width - drawW) / 2;
+        int oy = (height - drawH) / 2;
+        double lx = (mouseX - ox) / scale;
+        double ly = (mouseY - oy) / scale;
+        int ix = (int) Math.clamp(lx, 0.0d, logicalWidth - 1.0d);
+        int iy = (int) Math.clamp(ly, 0.0d, logicalHeight - 1.0d);
+        return Vec2i.of(ix, iy);
+    }
+
+    private void sendMouse(double lx, double ly) {
+        var p = toLogical(lx, ly);
+        SunscreenLibrary.library().intermediate().clientMenuMouse(p.x(), p.y(), leftClicked, rightClicked);
+    }
+
+    private void sendScroll(double deltaY) {
+        SunscreenLibrary.library().intermediate().clientMenuScroll((float) deltaY);
+    }
+
+    private void sendTextAppend(@NotNull String chars) {
+        SunscreenLibrary.library().intermediate().clientMenuTextAppend(chars);
+    }
+
+    private void sendTextBackspace() {
+        SunscreenLibrary.library().intermediate().clientMenuTextBackspace();
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        long now = System.currentTimeMillis();
+        if (now - lastMoveSendMs >= 33) {
+            lastMoveSendMs = now;
+            sendMouse(mouseX, mouseY);
+        }
+        super.mouseMoved(mouseX, mouseY);
+    }
+
+    private boolean onMouseClicked(double mouseX, double mouseY, int button) {
+        if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT || button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+            if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                leftClicked = true;
+            }
+            if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+                rightClicked = true;
+            }
+            sendMouse(mouseX, mouseY);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean onMouseReleased(double mouseX, double mouseY, int button) {
+        if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT || button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+            if (button == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                leftClicked = false;
+            }
+            if (button == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+                rightClicked = false;
+            }
+            sendMouse(mouseX, mouseY);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean onKeyPressed(int keyCode, int scanCode, int modifiers) {
+        if (keyCode == GLFW.GLFW_KEY_BACKSPACE) {
+            sendTextBackspace();
+            return true;
+        }
+        if (hasControlDown(modifiers) && keyCode == GLFW.GLFW_KEY_V) {
+            long window = nativeWindowHandle(Minecraft.getInstance());
+            String clip = glfwGetClipboardString(window);
+            if (clip != null && !clip.isEmpty()) {
+                int n = Math.min(clip.length(), 8192);
+                sendTextAppend(clip.substring(0, n));
+            }
+            return true;
+        }
+        String typed = keyToText(keyCode, modifiers);
+        if (!typed.isEmpty()) {
+            sendTextAppend(typed);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean hasControlDown(int modifiers) {
+        return (modifiers & GLFW.GLFW_MOD_CONTROL) != 0;
+    }
+
+    private static boolean hasShiftDown(int modifiers) {
+        return (modifiers & GLFW.GLFW_MOD_SHIFT) != 0;
+    }
+
+    private static boolean hasCapsLock(int modifiers) {
+        return (modifiers & GLFW.GLFW_MOD_CAPS_LOCK) != 0;
+    }
+
+    private static String keyToText(int keyCode, int modifiers) {
+        boolean shift = hasShiftDown(modifiers);
+        boolean caps = hasCapsLock(modifiers);
+
+        if (keyCode >= GLFW.GLFW_KEY_A && keyCode <= GLFW.GLFW_KEY_Z) {
+            char base = (char) ('a' + (keyCode - GLFW.GLFW_KEY_A));
+            return Character.toString((shift ^ caps) ? Character.toUpperCase(base) : base);
+        }
+        if (keyCode >= GLFW.GLFW_KEY_0 && keyCode <= GLFW.GLFW_KEY_9) {
+            final char[] normal = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+            final char[] shifted = {')', '!', '@', '#', '$', '%', '^', '&', '*', '('};
+            int idx = keyCode - GLFW.GLFW_KEY_0;
+            return Character.toString(shift ? shifted[idx] : normal[idx]);
+        }
+        if (keyCode >= GLFW.GLFW_KEY_KP_0 && keyCode <= GLFW.GLFW_KEY_KP_9) {
+            return Character.toString((char) ('0' + (keyCode - GLFW.GLFW_KEY_KP_0)));
+        }
+        return switch (keyCode) {
+            case GLFW.GLFW_KEY_SPACE -> " ";
+            case GLFW.GLFW_KEY_APOSTROPHE -> shift ? "\"" : "'";
+            case GLFW.GLFW_KEY_COMMA -> shift ? "<" : ",";
+            case GLFW.GLFW_KEY_MINUS -> shift ? "_" : "-";
+            case GLFW.GLFW_KEY_PERIOD -> shift ? ">" : ".";
+            case GLFW.GLFW_KEY_SLASH -> shift ? "?" : "/";
+            case GLFW.GLFW_KEY_SEMICOLON -> shift ? ":" : ";";
+            case GLFW.GLFW_KEY_EQUAL -> shift ? "+" : "=";
+            case GLFW.GLFW_KEY_LEFT_BRACKET -> shift ? "{" : "[";
+            case GLFW.GLFW_KEY_BACKSLASH -> shift ? "|" : "\\";
+            case GLFW.GLFW_KEY_RIGHT_BRACKET -> shift ? "}" : "]";
+            case GLFW.GLFW_KEY_GRAVE_ACCENT -> shift ? "~" : "`";
+            default -> "";
+        };
+    }
+
+    private static long nativeWindowHandle(Minecraft minecraft) {
+        var window = minecraft.getWindow();
+        #if MC_1_21_1
+        return window.getWindow();
+        #elif MC_1_21_11
+        return window.handle();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    private void registerInputHooks() {
+        ScreenMouseEvents.allowMouseClick(this)
+        #if MC_1_21_1
+                .register((s, x, y, button) -> !onMouseClicked(x, y, button))
+        #elif MC_1_21_11
+                .register((s, ctx) -> !onMouseClicked(ctx.x(), ctx.y(), ctx.button()));
+        #endif;
+        ScreenMouseEvents.allowMouseRelease(this)
+        #if MC_1_21_1
+                .register((s, x, y, button) -> !onMouseReleased(x, y, button))
+        #elif MC_1_21_11
+                .register((s, ctx) -> !onMouseReleased(ctx.x(), ctx.y(), ctx.button()));
+        #endif;
+        ScreenKeyboardEvents.allowKeyPress(this)
+        #if MC_1_21_1
+                .register((s, key, scancode, modifiers) -> !onKeyPressed(key, scancode, modifiers))
+        #elif MC_1_21_11
+                .register((s, ctx) -> !onKeyPressed(ctx.key(), ctx.scancode(), ctx.modifiers()));
+        #endif;
+    }
+
+
+    @Override
+    public void renderBackground(GuiGraphics guiGraphics, int i, int j, float f) {
+        // No background for sunscreens
+    }
+
+    @Override
+    public void render(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        if (canvas == null || logicalWidth <= 0 || logicalHeight <= 0 || rasterWidth <= 0 || rasterHeight <= 0) {
+            return;
+        }
+        Minecraft mc = Minecraft.getInstance();
+        int vw = mc.getWindow().getGuiScaledWidth();
+        int vh = mc.getWindow().getGuiScaledHeight();
+        float scale = Math.min(
+                (float) vw / logicalWidth,
+                (float) vh / logicalHeight
+        );
+        int drawW = Math.round(logicalWidth * scale);
+        int drawH = Math.round(logicalHeight * scale);
+        int ox = (vw - drawW) / 2;
+        int oy = (vh - drawH) / 2;
+        float uMax = (float) logicalWidth / rasterWidth;
+        float vMax = (float) logicalHeight / rasterHeight;
+        canvas.draw(graphics, ox, oy, drawW, drawH, uMax, vMax);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
+    public void onClose() {
+        if (canvas != null) {
+            canvas.close();
+            canvas = null;
+        }
+        super.onClose();
+        NativeMenuRasterReceiver.resetAll();
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/SunscreenFabricMod.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/SunscreenFabricMod.java
@@ -1,0 +1,133 @@
+package me.combimagnetron.sunscreen.fabric;
+
+import com.mojang.brigadier.context.CommandContext;
+import me.combimagnetron.passport.Passport;
+import me.combimagnetron.passport.util.data.Identifier;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.fabric.nativeui.FabricNativeUiNetworking;
+import me.combimagnetron.sunscreen.fabric.user.UserImpl;
+import me.combimagnetron.sunscreen.neo.ActiveMenu;
+import me.combimagnetron.sunscreen.neo.TestMenuTemplate;
+import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.font.AtlasFont;
+import me.combimagnetron.sunscreen.neo.registry.Registries;
+import me.combimagnetron.sunscreen.util.FileProvider;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+public final class SunscreenFabricMod implements ModInitializer {
+    private static final Identifier FONT_ID = Identifier.of("sunscreen", "font/minecraft");
+    private static final Identifier SMALL_FONT_ID = Identifier.of("sunscreen", "font/sunburned");
+    private static SunscreenLibraryFabric library;
+
+    @Override
+    public void onInitialize() {
+        library = new SunscreenLibraryFabric(this);
+        SunscreenLibrary.Holder.INSTANCE = library;
+        Passport.Holder.INSTANCE = library.passport();
+        AtlasFont atlasFont = AtlasFont.font(FONT_ID)
+            .fromTtfFile(FileProvider.resource().find("minecraft_font.ttf").toPath(), 8);
+        AtlasFont sunburned = AtlasFont.font(SMALL_FONT_ID)
+            .fromTtfFile(FileProvider.resource().find("sunburned.ttf").toPath(), 15.8f);
+        Registries.register(Registries.FONTS, atlasFont);
+        Registries.register(Registries.FONTS, sunburned);
+
+        FabricNativeUiNetworking.registerPayloadTypes();
+
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> FabricNativeUiNetworking.registerServerReceivers());
+
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+            dispatcher.register(
+                Commands.literal("sunscreen")
+                    .then(Commands.literal("handshake")
+                        .executes(SunscreenFabricMod::handshakeStatus))
+                    .then(Commands.literal("onlynative")
+                        .executes(SunscreenFabricMod::openMenuNativeRequired))
+                    .executes(SunscreenFabricMod::openMenuDefault)
+            )
+        );
+        library().logger().info("Sunscreen has started.");
+    }
+
+    private static int handshakeStatus(CommandContext<CommandSourceStack> context) {
+        if (library == null) {
+            context.getSource().sendFailure(Component.literal("Sunscreen: server mod not initialised."));
+            return 0;
+        }
+        if (!(context.getSource().getEntity() instanceof ServerPlayer player)) {
+            context.getSource().sendFailure(Component.literal("Sunscreen: run this as a player."));
+            return 0;
+        }
+        UserImpl user = library.userManager().ensureUser(player);
+        if (!user.useNativeUi()) {
+            context.getSource().sendSuccess(
+                () -> Component.literal(
+                    "Sunscreen: server has no native UI handshake for you yet. "
+                        + "With the client mod, join play and watch log Sunscreen/NativeUi."
+                ),
+                false
+            );
+            return 1;
+        }
+        context.getSource().sendSuccess(
+            () -> Component.literal(
+                "Sunscreen: handshake present — nativeRenderer=true"
+            ),
+            false
+        );
+        return 1;
+    }
+
+    private static int openMenuDefault(CommandContext<CommandSourceStack> context) {
+        return openTestMenu(context, false);
+    }
+
+    private static int openMenuNativeRequired(CommandContext<CommandSourceStack> context) {
+        return openTestMenu(context, true);
+    }
+
+    private static int openTestMenu(CommandContext<CommandSourceStack> context, boolean requireNativeHandshake) {
+        if (library == null) {
+            context.getSource().sendFailure(Component.literal("Sunscreen: server mod not initialised."));
+            return 0;
+        }
+        try {
+            if (!(context.getSource().getEntity() instanceof ServerPlayer player)) {
+                context.getSource().sendFailure(Component.literal("Sunscreen: this command must be run by a player."));
+                return 0;
+            }
+            UserImpl user = library.userManager().user(player);
+            if (user == null) {
+                library.logger().error("Sunscreen /sunscreen: no UserImpl for player {}", player.getUUID());
+                context.getSource().sendFailure(Component.literal("Sunscreen: internal error (no user record). Rejoin the world."));
+                return 0;
+            }
+            if (requireNativeHandshake) {
+                if (!user.useNativeUi()) {
+                    context.getSource().sendFailure(Component.literal(
+                        "Sunscreen: native UI handshake missing on the server for this player. "
+                            + "Use the Sunscreen Fabric client, enter play, then try again or run /sunscreen handshake."
+                    ));
+                    return 0;
+                }
+            }
+            new ActiveMenu(new TestMenuTemplate(), user, Identifier.of("aa"));
+            return 1;
+        } catch (Throwable t) {
+            library.logger().error("Sunscreen /sunscreen command failed", t);
+            String detail = t.getMessage() == null ? "(no message)" : t.getMessage();
+            context.getSource().sendFailure(
+                Component.literal("Sunscreen: " + t.getClass().getSimpleName() + ": " + detail)
+            );
+            return 0;
+        }
+    }
+
+    public static SunscreenLibraryFabric library() {
+        return library;
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/SunscreenLibraryFabric.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/SunscreenLibraryFabric.java
@@ -1,0 +1,109 @@
+package me.combimagnetron.sunscreen.fabric;
+
+import me.combimagnetron.passport.Passport;
+import me.combimagnetron.passport.user.UserHandler;
+import me.combimagnetron.passport.util.placeholder.PlaceholderRegistry;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricPlatformProtocolIntermediate;
+import me.combimagnetron.sunscreen.fabric.user.UserImpl;
+import me.combimagnetron.sunscreen.fabric.user.UserManager;
+import me.combimagnetron.sunscreen.neo.protocol.PlatformProtocolIntermediate;
+import me.combimagnetron.sunscreen.neo.session.SessionHandler;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import net.fabricmc.loader.api.FabricLoader;
+import net.kyori.adventure.audience.Audience;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public final class SunscreenLibraryFabric implements SunscreenLibrary<Object, Audience, ItemStack> {
+    private final FabricPlatformProtocolIntermediate intermediate = new FabricPlatformProtocolIntermediate();
+    private final SessionHandler sessionHandler = new SessionHandler();
+    private final PlaceholderRegistry placeholderRegistry = new PlaceholderRegistry.Impl();
+    private final UserManager userManager = new UserManager();
+    private final Object plugin;
+    private final Logger logger = LoggerFactory.getLogger("Sunscreen");
+
+    public SunscreenLibraryFabric(Object plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Passport<Object> passport() {
+        return new Passport<>() {
+            @Override
+            public UserHandler<Audience, SunscreenUser<Audience>> users() {
+                return userManager;
+            }
+
+            @Override
+            public Path dataFolder() {
+                return path();
+            }
+
+            @Override
+            public PlaceholderRegistry placeholders() {
+                return placeholderRegistry;
+            }
+
+            @Override
+            public Object packetEventsApi() {
+                return null;
+            }
+
+            @Override
+            public Object plugin() {
+                return plugin;
+            }
+        };
+    }
+
+    @Override
+    public Path path() {
+        return FabricLoader.getInstance().getConfigDir().resolve("sunscreen");
+    }
+
+    @Override
+    public @NotNull Object plugin() {
+        return plugin;
+    }
+
+    @Override
+    public @Nullable InputStream resource(String path) {
+        String resourcePath = path.startsWith("/") ? path : "/" + path;
+        return SunscreenLibraryFabric.class.getResourceAsStream(resourcePath);
+    }
+
+    @Override
+    public @NotNull SessionHandler sessionHandler() {
+        return sessionHandler;
+    }
+
+    @Override
+    public @NotNull UserHandler<Audience, SunscreenUser<Audience>> users() {
+        return userManager;
+    }
+
+    @Override
+    public @NotNull Logger logger() {
+        return logger;
+    }
+
+    @Override
+    public @NotNull PlatformProtocolIntermediate<ItemStack> intermediate() {
+        return intermediate;
+    }
+
+    public UserManager userManager() {
+        return userManager;
+    }
+
+    public @Nullable UserImpl user(java.util.UUID uuid) {
+        return userManager.userRaw(uuid);
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/mixin/ServerCommonPacketListenerImplMixin.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/mixin/ServerCommonPacketListenerImplMixin.java
@@ -1,0 +1,30 @@
+package me.combimagnetron.sunscreen.fabric.mixin;
+
+import com.mojang.authlib.GameProfile;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMenuTimePackets;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(ServerCommonPacketListenerImpl.class)
+public abstract class ServerCommonPacketListenerImplMixin {
+
+    @Shadow
+    protected abstract GameProfile playerProfile();
+
+    @Shadow
+    @Final
+    protected MinecraftServer server;
+
+    @ModifyVariable(method = "send(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketSendListener;)V", at = @At("HEAD"), argsOnly = true)
+    private Packet<?> sunscreen$rewriteMenuWorldTime(Packet<?> packet) {
+        var player = server.getPlayerList().getPlayer(FabricMappingCompat.gameProfileId(playerProfile()));
+        return FabricMenuTimePackets.maybeRewriteTimePacket(player, packet);
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/mixin/ServerGamePacketListenerImplMixin.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/mixin/ServerGamePacketListenerImplMixin.java
@@ -1,0 +1,83 @@
+package me.combimagnetron.sunscreen.fabric.mixin;
+
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMenuTimePackets;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricPacketBridge;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
+import net.minecraft.network.protocol.game.ServerboundContainerClosePacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundMovePlayerPacket;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
+import net.minecraft.network.protocol.game.ServerboundRenameItemPacket;
+import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
+import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.network.ServerPlayerConnection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class ServerGamePacketListenerImplMixin implements ServerPlayerConnection {
+    @Shadow
+    public ServerPlayer player;
+
+    @Inject(method = "handleMovePlayer", at = @At("HEAD"))
+    private void sunscreen$onMove(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleRotation(player, packet.getYRot(player.getYRot()), packet.getXRot(player.getXRot()));
+    }
+
+    @Inject(method = "handlePlayerCommand", at = @At("HEAD"))
+    private void sunscreen$onPlayerCommand(ServerboundPlayerCommandPacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleSneak(player, FabricMappingCompat.isPressShift(packet.getAction()));
+    }
+
+    @Inject(method = "handlePlayerAction", at = @At("HEAD"), cancellable = true)
+    private void sunscreen$onPlayerAction(ServerboundPlayerActionPacket packet, CallbackInfo ci) {
+        boolean cancel = FabricPacketBridge.handleDigging(player, packet);
+        if (cancel) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "handleUseItem", at = @At("HEAD"), cancellable = true)
+    private void sunscreen$onUseItem(ServerboundUseItemPacket packet, CallbackInfo ci) {
+        if (FabricPacketBridge.handleUseItem(player, packet.getHand())) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "handleInteract", at = @At("HEAD"), cancellable = true)
+    private void sunscreen$onInteract(ServerboundInteractPacket packet, CallbackInfo ci) {
+        if (FabricPacketBridge.handleInteractEntity(player, packet)) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "handleRenameItem", at = @At("HEAD"))
+    private void sunscreen$onRename(ServerboundRenameItemPacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleNameItem(player, packet.getName());
+    }
+
+    @Inject(method = "handleSetCarriedItem", at = @At("HEAD"))
+    private void sunscreen$onSetCarriedItem(ServerboundSetCarriedItemPacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleSlotChange(player, packet.getSlot());
+    }
+
+    @Inject(method = "handleContainerClick", at = @At("HEAD"))
+    private void sunscreen$onContainerClick(ServerboundContainerClickPacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleContainerClick(player, FabricMappingCompat.containerId(packet));
+    }
+
+    @Inject(method = "handleContainerClose", at = @At("HEAD"))
+    private void sunscreen$onContainerClose(ServerboundContainerClosePacket packet, CallbackInfo ci) {
+        FabricPacketBridge.handleContainerClose(player);
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/FabricNativeUiNetworking.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/FabricNativeUiNetworking.java
@@ -1,0 +1,52 @@
+package me.combimagnetron.sunscreen.fabric.nativeui;
+
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.fabric.user.UserImpl;
+import me.combimagnetron.sunscreen.nativeui.NativeUi;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.server.level.ServerPlayer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Registers the single native-UI chunk payload (both directions) and the C2S receiver.
+ */
+public final class FabricNativeUiNetworking {
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sunscreen/NativeUi");
+    private static final AtomicBoolean PAYLOAD_TYPES_REGISTERED = new AtomicBoolean(false);
+    private static final AtomicBoolean SERVER_RECEIVERS_REGISTERED = new AtomicBoolean(false);
+
+    private FabricNativeUiNetworking() {
+    }
+
+    public static void registerPayloadTypes() {
+        if (!PAYLOAD_TYPES_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        PayloadTypeRegistry.playC2S().register(NativeUiChunkC2SPayload.TYPE, NativeUiChunkC2SPayload.STREAM_CODEC);
+        PayloadTypeRegistry.playS2C().register(NativeUiChunkS2CPayload.TYPE, NativeUiChunkS2CPayload.STREAM_CODEC);
+    }
+
+    public static void registerServerReceivers() {
+        if (!SERVER_RECEIVERS_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        ServerPlayNetworking.registerGlobalReceiver(NativeUiChunkC2SPayload.TYPE, (payload, context) -> {
+            context.server().execute(() -> {
+                ServerPlayer player = context.player();
+                UserImpl user = UserImpl.tryOf(player);
+                if (user == null) {
+                    LOGGER.warn(
+                        "Native UI chunk ignored for {}: user not ready.",
+                        FabricMappingCompat.gameProfileName(player.getGameProfile())
+                    );
+                    return;
+                }
+                NativeUi.receiveServerC2SPacket(user, payload.data());
+            });
+        });
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/NativeUiChunkC2SPayload.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/NativeUiChunkC2SPayload.java
@@ -1,0 +1,30 @@
+package me.combimagnetron.sunscreen.fabric.nativeui;
+
+import io.netty.buffer.ByteBuf;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.nativeui.NativeUi;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import org.jetbrains.annotations.NotNull;
+
+public record NativeUiChunkC2SPayload(
+    byte @NotNull [] data
+) implements CustomPacketPayload {
+    public static final CustomPacketPayload.Type<NativeUiChunkC2SPayload> TYPE =
+        FabricMappingCompat.customPayloadType(NativeUi.CHANNEL);
+
+    public static final StreamCodec<ByteBuf, NativeUiChunkC2SPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, p) -> buf.writeBytes(p.data()),
+        buf -> {
+            int len = buf.readableBytes();
+            byte[] out = new byte[len];
+            buf.readBytes(out);
+            return new NativeUiChunkC2SPayload(out);
+        }
+    );
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/NativeUiChunkS2CPayload.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/nativeui/NativeUiChunkS2CPayload.java
@@ -1,0 +1,30 @@
+package me.combimagnetron.sunscreen.fabric.nativeui;
+
+import io.netty.buffer.ByteBuf;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.nativeui.NativeUi;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import org.jetbrains.annotations.NotNull;
+
+public record NativeUiChunkS2CPayload(
+    byte @NotNull [] data
+) implements CustomPacketPayload {
+    public static final CustomPacketPayload.Type<NativeUiChunkS2CPayload> TYPE =
+        FabricMappingCompat.customPayloadType(NativeUi.CHANNEL);
+
+    public static final StreamCodec<ByteBuf, NativeUiChunkS2CPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, p) -> buf.writeBytes(p.data()),
+            buf -> {
+                int len = buf.readableBytes();
+                byte[] out = new byte[len];
+                buf.readBytes(out);
+                return new NativeUiChunkS2CPayload(out);
+            }
+    );
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricMappingCompat.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricMappingCompat.java
@@ -1,0 +1,204 @@
+package me.combimagnetron.sunscreen.fabric.protocol;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
+import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.item.component.CustomModelData;
+#if MC_1_21_1
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.protocol.game.ClientboundSetCarriedItemPacket;
+#elif MC_1_21_11
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.resources.Identifier;
+import net.minecraft.network.protocol.game.ClientboundSetHeldSlotPacket;
+import java.util.List;
+#endif
+
+import java.util.UUID;
+
+public final class FabricMappingCompat {
+
+    private FabricMappingCompat() {
+    }
+
+    public static UUID gameProfileId(GameProfile profile) {
+        #if MC_1_21_1
+        return profile.getId();
+        #elif MC_1_21_11
+        return profile.id();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static String gameProfileName(GameProfile profile) {
+        #if MC_1_21_1
+        return profile.getName();
+        #elif MC_1_21_11
+        return profile.name();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static Object gameProfileProperties(GameProfile profile) {
+        #if MC_1_21_1
+        return profile.getProperties();
+        #elif MC_1_21_11
+        return profile.properties();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static ServerLevel serverLevel(ServerPlayer player) {
+        return (ServerLevel) player.level();
+    }
+
+    public static <T extends Entity> T create(ServerLevel level, EntityType<T> type) {
+        #if MC_1_21_1
+        return type.create(level);
+        #elif MC_1_21_11
+        return type.create(level, EntitySpawnReason.COMMAND);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static void startRiding(ServerPlayer player, Entity mount) {
+        #if MC_1_21_1
+        player.startRiding(mount, true);
+        #elif MC_1_21_11
+        player.startRiding(mount, true, true);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static void teleport(ServerPlayer player, ServerLevel level, double x, double y, double z, float yaw, float pitch) {
+        #if MC_1_21_1
+        player.teleportTo(level, x, y, z, java.util.Set.of(), yaw, pitch);
+        #elif MC_1_21_11
+        player.teleportTo(level, x, y, z, java.util.Set.of(), yaw, pitch, false);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static int containerId(ServerboundContainerClickPacket packet) {
+        #if MC_1_21_1
+        return packet.getContainerId();
+        #elif MC_1_21_11
+        return packet.containerId();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static boolean isPressShift(Object action) {
+        String name = String.valueOf(action);
+        return "PRESS_SHIFT_KEY".equals(name) || "PRESS_SHIFT".equals(name);
+    }
+
+    public static long getDayTime(ClientboundSetTimePacket packet) {
+        #if MC_1_21_1
+        return packet.getDayTime();
+        #elif MC_1_21_11
+        return packet.dayTime();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static ClientboundPlayerInfoUpdatePacket.Entry playerInfoEntry(
+        UUID uuid,
+        GameProfile profile,
+        boolean listed,
+        int latency,
+        Object gameType,
+        Object displayName
+    ) {
+        #if MC_1_21_1
+        return new ClientboundPlayerInfoUpdatePacket.Entry(
+            uuid,
+            profile,
+            listed,
+            latency,
+            (net.minecraft.world.level.GameType) gameType,
+            (net.minecraft.network.chat.Component) displayName,
+            null
+        );
+        #elif MC_1_21_11
+        return new ClientboundPlayerInfoUpdatePacket.Entry(
+            uuid,
+            profile,
+            listed,
+            latency,
+            (net.minecraft.world.level.GameType) gameType,
+            (net.minecraft.network.chat.Component) displayName,
+            false,
+            0,
+            null
+        );
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static Packet<?> createSetCarriedItemPacket(int slot) {
+        #if MC_1_21_1
+        return new ClientboundSetCarriedItemPacket(slot);
+        #elif MC_1_21_11
+        return new ClientboundSetHeldSlotPacket(slot);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static Object parse(String id) {
+        #if MC_1_21_1
+        return ResourceLocation.parse(id);
+        #elif MC_1_21_11
+        return Identifier.parse(id);
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static <T extends CustomPacketPayload> CustomPacketPayload.Type<T> customPayloadType(String id) {
+        #if MC_1_21_1
+        return new CustomPacketPayload.Type<>((ResourceLocation) parse(id));
+        #elif MC_1_21_11
+        return new CustomPacketPayload.Type<>((Identifier) parse(id));
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static String namespacedPath(Object key) {
+        #if MC_1_21_1
+        return ((ResourceLocation) key).getPath();
+        #elif MC_1_21_11
+        return ((Identifier) key).getPath();
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+
+    public static CustomModelData customModelData(int id) {
+        #if MC_1_21_1
+        return new CustomModelData(id);
+        #elif MC_1_21_11
+        return new CustomModelData(List.of(), List.of(), List.of(), List.of(id));
+        #else
+        throw new IllegalStateException("Unsupported minecraft version");
+        #endif
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricMenuTimePackets.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricMenuTimePackets.java
@@ -1,0 +1,24 @@
+package me.combimagnetron.sunscreen.fabric.protocol;
+
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Rewrites vanilla world time packets for players in a Sunscreen menu so the client sees a fixed
+ * world age (-50) without changing {@link net.minecraft.server.level.ServerLevel} time.
+ */
+public final class FabricMenuTimePackets {
+    private FabricMenuTimePackets() {
+    }
+
+    public static Packet<?> maybeRewriteTimePacket(ServerPlayer player, Packet<?> packet) {
+        if (!(packet instanceof ClientboundSetTimePacket setTime)) {
+            return packet;
+        }
+        if (!FabricPacketBridge.inMenu(player)) {
+            return packet;
+        }
+        return new ClientboundSetTimePacket(-50L, FabricMappingCompat.getDayTime(setTime), true);
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricPacketBridge.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricPacketBridge.java
@@ -1,0 +1,222 @@
+package me.combimagnetron.sunscreen.fabric.protocol;
+
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.fabric.user.UserImpl;
+import me.combimagnetron.sunscreen.neo.input.InputHandler;
+import me.combimagnetron.sunscreen.neo.input.context.MouseInputContext;
+import me.combimagnetron.sunscreen.neo.input.context.ScrollInputContext;
+import me.combimagnetron.sunscreen.neo.input.context.TextInputContext;
+import me.combimagnetron.sunscreen.neo.session.Session;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import me.combimagnetron.sunscreen.util.Scheduler;
+import me.combimagnetron.sunscreen.util.helper.RotationHelper;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.protocol.game.ClientboundContainerClosePacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import org.jetbrains.annotations.NotNull;
+
+public final class FabricPacketBridge {
+    private FabricPacketBridge() {
+    }
+
+    public static boolean inMenu(@NotNull ServerPlayer player) {
+        UserImpl user = tryUser(player);
+        return user != null && SunscreenLibrary.library().sessionHandler().inMenu(user);
+    }
+
+    public static void handleRotation(@NotNull ServerPlayer player, float yaw, float pitch) {
+        SunscreenUser<?> user = user(player);
+        if (!inMenu(player)) {
+            return;
+        }
+        Session session = user.session();
+        if (session == null) {
+            return;
+        }
+        if (session.menu().useNativeClientPath()) {
+            return;
+        }
+        InputHandler inputHandler = session.menu().inputHandler();
+        inputHandler.peek(MouseInputContext.class, old -> old.withPosition(RotationHelper.convert(yaw, pitch, user.screenInfo())), user);
+    }
+
+    public static void handleSneak(@NotNull ServerPlayer player, boolean shiftPressed) {
+        if (!shiftPressed || !inMenu(player)) {
+            return;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session != null) {
+            session.menu().close();
+        }
+    }
+
+    public static boolean handleDigging(@NotNull ServerPlayer player, @NotNull ServerboundPlayerActionPacket packet) {
+        ServerboundPlayerActionPacket.Action action = packet.getAction();
+        boolean startDigging = action == ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK;
+        boolean cancelDigging = action == ServerboundPlayerActionPacket.Action.ABORT_DESTROY_BLOCK;
+        boolean releaseUseItem = action == ServerboundPlayerActionPacket.Action.RELEASE_USE_ITEM;
+        if (!inMenu(player)) {
+            if (startDigging) {
+                var state = player.level().getBlockState(packet.getPos());
+                Object id = BuiltInRegistries.BLOCK.getKey(state.getBlock());
+                if (FabricMappingCompat.namespacedPath(id).contains("copper_grate")) {
+                    player.level().playSound(player, packet.getPos(), SoundEvents.COPPER_GRATE_HIT, SoundSource.BLOCKS, 1f, 1f);
+                }
+            }
+            return false;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return false;
+        }
+        InputHandler inputHandler = session.menu().inputHandler();
+        if (releaseUseItem) {
+            inputHandler.peek(MouseInputContext.class, old -> old.withRightPressed(false), user);
+        }
+        if (startDigging) {
+            inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(true), user);
+            return true;
+        }
+        if (cancelDigging) {
+            inputHandler.peek(MouseInputContext.class, old -> old.withLeftPressed(false), user);
+            return true;
+        }
+        return true;
+    }
+
+    /**
+     * @return true if the use-item packet should be cancelled (Spigot parity: do not swing/consume items in menu).
+     */
+    public static boolean handleUseItem(@NotNull ServerPlayer player, @NotNull InteractionHand hand) {
+        if (!inMenu(player)) {
+            return false;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return false;
+        }
+        if (hand == InteractionHand.MAIN_HAND) {
+            session.menu().inputHandler().peek(MouseInputContext.class, old -> old.withRightPressed(true), user);
+        }
+        return true;
+    }
+
+    /**
+     * @return true if the interact packet should be cancelled (Spigot parity: block self-interact while in menu).
+     */
+    public static boolean handleInteractEntity(@NotNull ServerPlayer player, @NotNull ServerboundInteractPacket packet) {
+        if (!inMenu(player)) {
+            return false;
+        }
+        net.minecraft.world.entity.Entity target = packet.getTarget(FabricMappingCompat.serverLevel(player));
+        if (target == null) {
+            return false;
+        }
+        SunscreenUser<?> user = user(player);
+        return target.getId() == user.entityId();
+    }
+
+    public static void handleNameItem(@NotNull ServerPlayer player, @NotNull String itemName) {
+        if (!inMenu(player)) {
+            return;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return;
+        }
+        InputHandler inputHandler = session.menu().inputHandler();
+        TextInputContext context = inputHandler.context(TextInputContext.class);
+        if (!context.active()) {
+            return;
+        }
+        if (itemName.length() == 50) {
+            inputHandler.peek(TextInputContext.class, old -> old.append(itemName), user);
+            SunscreenLibrary.library().intermediate().openEmptyAnvil(user);
+            return;
+        }
+        inputHandler.peek(TextInputContext.class, old -> old.withStream(itemName), user);
+    }
+
+    public static void handleSlotChange(@NotNull ServerPlayer player, int slot) {
+        if (!inMenu(player)) {
+            return;
+        }
+        if (slot == 4) {
+            return;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return;
+        }
+        session.menu().inputHandler().peek(ScrollInputContext.class, old -> old.onSlotChange(slot), user);
+        player.connection.send(FabricMappingCompat.createSetCarriedItemPacket(4));
+    }
+
+    public static void handleContainerClick(@NotNull ServerPlayer player, int containerId) {
+        if (!inMenu(player)) {
+            return;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return;
+        }
+        InputHandler inputHandler = session.menu().inputHandler();
+        TextInputContext context = inputHandler.context(TextInputContext.class);
+        if (!context.active()) {
+            return;
+        }
+        inputHandler.peek(TextInputContext.class, old -> old.withActive(false), user);
+        SunscreenLibrary.library().intermediate().sendItems(user);
+        Scheduler.delayTick(() -> {
+            player.connection.send(new ClientboundContainerClosePacket(containerId));
+            if (player.containerMenu != null && player.containerMenu.containerId == containerId) {
+                player.closeContainer();
+            }
+        });
+    }
+
+    public static void handleContainerClose(@NotNull ServerPlayer player) {
+        if (!inMenu(player)) {
+            return;
+        }
+        SunscreenUser<?> user = user(player);
+        Session session = user.session();
+        if (session == null) {
+            return;
+        }
+        InputHandler inputHandler = session.menu().inputHandler();
+        TextInputContext context = inputHandler.context(TextInputContext.class);
+        if (!context.active()) {
+            return;
+        }
+        SunscreenLibrary.library().intermediate().sendItems(user);
+        inputHandler.peek(TextInputContext.class, old -> old.withActive(false), user);
+    }
+
+    private static UserImpl user(ServerPlayer player) {
+        UserImpl user = tryUser(player);
+        if (user == null) {
+            throw new IllegalStateException("No Sunscreen user found for " + player.getUUID());
+        }
+        return user;
+    }
+
+    private static UserImpl tryUser(ServerPlayer player) {
+        me.combimagnetron.sunscreen.fabric.SunscreenLibraryFabric library = me.combimagnetron.sunscreen.fabric.SunscreenFabricMod.library();
+        if (library == null) {
+            return null;
+        }
+        return library.user(player.getUUID());
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricPlatformProtocolIntermediate.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/protocol/FabricPlatformProtocolIntermediate.java
@@ -1,0 +1,422 @@
+package me.combimagnetron.sunscreen.fabric.protocol;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.mojang.authlib.GameProfile;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
+import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.fabric.nativeui.NativeUiChunkC2SPayload;
+import me.combimagnetron.sunscreen.fabric.nativeui.NativeUiChunkS2CPayload;
+import me.combimagnetron.sunscreen.fabric.user.UserImpl;
+import me.combimagnetron.sunscreen.nativeui.NativeUiChunkBinary;
+import me.combimagnetron.sunscreen.neo.graphic.Item;
+import me.combimagnetron.sunscreen.neo.protocol.PlatformProtocolIntermediate;
+import me.combimagnetron.sunscreen.neo.protocol.type.EntityReference;
+import me.combimagnetron.sunscreen.neo.protocol.type.Location;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import io.netty.buffer.Unpooled;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.network.protocol.game.ClientboundBundlePacket;
+import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
+import net.minecraft.network.protocol.game.ClientboundEntityEventPacket;
+import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
+import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveMobEffectPacket;
+import net.minecraft.network.protocol.game.ClientboundSetCameraPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
+import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.SimpleMenuProvider;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.CustomModelData;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.level.GameType;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public final class FabricPlatformProtocolIntermediate implements PlatformProtocolIntermediate<ItemStack> {
+    private static final int DISPLAY_ENTITY_ID = -10_000;
+
+    private final Table<UUID, Integer, Object> entities = HashBasedTable.create();
+    private static Consumer<NativeUiChunkC2SPayload> sender;
+
+    @Override
+    public EntityReference<?> spawnAndRideHorse(@NotNull SunscreenUser<?> user, @NotNull Location location) {
+        ServerPlayer player = fabricPlayer(user);
+        var level = FabricMappingCompat.serverLevel(player);
+        net.minecraft.world.entity.Entity horse = FabricMappingCompat.create(level, EntityType.HORSE);
+        if (horse == null) {
+            throw new IllegalStateException("Unable to spawn horse entity");
+        }
+        horse.setPos(location.x(), location.y(), location.z());
+        horse.setInvisible(true);
+        horse.setInvulnerable(true);
+        horse.setSilent(true);
+        level.addFreshEntity(horse);
+        FabricMappingCompat.startRiding(player, horse);
+        entities.put(player.getUUID(), horse.getId(), horse);
+        return new EntityReference<>(horse.getId(), horse);
+    }
+
+    @Override
+    public EntityReference<?> spawnAndFillItemFrame(@NotNull SunscreenUser<?> user, @NotNull Location location, byte[] data, int mapId) {
+        ServerPlayer player = fabricPlayer(user);
+        updateMap(user, mapId, data);
+
+        final BlockPos pos = BlockPos.containing(location.x(), location.y(), location.z());
+        final ItemStack map = Items.FILLED_MAP.getDefaultInstance();
+        map.set(DataComponents.MAP_ID, new MapId(mapId));
+
+        var level = FabricMappingCompat.serverLevel(player);
+        ItemFrame upper = new ItemFrame(level, pos, Direction.UP);
+        upper.setInvisible(true);
+        upper.setInvulnerable(true);
+        upper.setItem(map.copy(), false);
+
+        ItemFrame lower = new ItemFrame(level, pos, Direction.DOWN);
+        lower.setInvisible(true);
+        lower.setInvulnerable(true);
+        lower.setItem(map.copy(), false);
+
+        level.addFreshEntity(upper);
+        level.addFreshEntity(lower);
+        entities.put(player.getUUID(), upper.getId(), upper);
+        entities.put(player.getUUID(), lower.getId(), lower);
+        return new EntityReference<>(upper.getId(), upper);
+    }
+
+    @Override
+    public EntityReference<?> spawnAndSpectateDisplay(@NotNull SunscreenUser<?> user, @NotNull Location location) {
+        ServerPlayer player = fabricPlayer(user);
+        long dayTimeArg = (long) user.worldTime();
+        sendTime(player, -500L, dayTimeArg);
+        fakeArmorStandHit(player);
+        sendTime(player, -50L, dayTimeArg);
+        player.connection.send(cameraPacketFor(player, DISPLAY_ENTITY_ID));
+        UUID displayUuid = UUID.randomUUID();
+        GameProfile displayProfile = new GameProfile(displayUuid, FabricMappingCompat.gameProfileName(player.getGameProfile()));
+        copyProfileProperties(displayProfile, player.getGameProfile());
+        ClientboundPlayerInfoUpdatePacket.Entry tabEntry = FabricMappingCompat.playerInfoEntry(
+                displayUuid,
+                displayProfile,
+                false,
+                0,
+                GameType.CREATIVE,
+                Component.empty()
+        );
+        ClientboundPlayerInfoUpdatePacket addPlayer = playerInfoAddPacket(player, tabEntry);
+        ClientboundAddEntityPacket spawn = new ClientboundAddEntityPacket(
+            DISPLAY_ENTITY_ID,
+            displayUuid,
+            player.getX(),
+            player.getY(),
+            player.getZ(),
+            player.getXRot(),
+            player.getYRot(),
+            EntityType.PLAYER,
+            0,
+            Vec3.ZERO,
+            player.getYHeadRot()
+        );
+        ClientboundSetEntityDataPacket metadata = new ClientboundSetEntityDataPacket(DISPLAY_ENTITY_ID, Collections.emptyList());
+        player.connection.send(new ClientboundUpdateMobEffectPacket(
+            player.getId(),
+            new MobEffectInstance(MobEffects.INVISIBILITY, MobEffectInstance.INFINITE_DURATION, 255, false, false, false),
+            false
+        ));
+        player.setInvisible(true);
+        sendItems(user);
+        player.connection.send(new ClientboundBundlePacket(List.of(addPlayer, spawn, metadata)));
+        player.connection.send(cameraPacketFor(player, DISPLAY_ENTITY_ID));
+        sendColumnBlock(player, Blocks.EXPOSED_COPPER_GRATE.defaultBlockState());
+        player.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, 0f));
+        return null;
+    }
+
+    @Override
+    public EntityReference<?> spawnItemDisplay(@NotNull SunscreenUser<?> user, @NotNull Location location, @NotNull Item<ItemStack> item, @NotNull Vec2i screenPos) {
+        return null;
+    }
+
+    @Override
+    public void setHorseArmor(@NotNull SunscreenUser<?> user, @NotNull String texturePath) {
+        ServerPlayer player = fabricPlayer(user);
+        LivingEntity horse = (LivingEntity) entities.row(player.getUUID()).values().stream()
+            .filter(value -> value instanceof LivingEntity living && living.getType() == EntityType.HORSE)
+            .findAny()
+            .orElse(null);
+        if (horse == null) {
+            return;
+        }
+        final ItemStack armor = Items.LEATHER_HORSE_ARMOR.getDefaultInstance();
+        armor.set(DataComponents.CUSTOM_MODEL_DATA, modelData("cursor_" + texturePath));
+        horse.setItemSlot(EquipmentSlot.BODY, armor);
+    }
+
+    @Override
+    public void removeEntity(@NotNull SunscreenUser<?> user, int id) {
+        ServerPlayer player = fabricPlayer(user);
+        entities.remove(player.getUUID(), id);
+        net.minecraft.world.entity.Entity entity = FabricMappingCompat.serverLevel(player).getEntity(id);
+        if (entity != null) {
+            entity.discard();
+        }
+    }
+
+    @Override
+    public void updateMap(@NotNull SunscreenUser<?> user, int mapId, byte @NotNull [] data) {
+        ServerPlayer player = fabricPlayer(user);
+        MapItemSavedData.MapPatch patch = new MapItemSavedData.MapPatch(0, 0, 128, 128, data);
+        player.connection.send(new ClientboundMapItemDataPacket(new MapId(mapId), (byte) 0, false, java.util.Optional.empty(), java.util.Optional.of(patch)));
+    }
+
+    @Override
+    public void reset(@NotNull SunscreenUser<?> user, @NotNull Vector3d initialRotation) {
+        ServerPlayer player = fabricPlayer(user);
+        player.connection.send(new ClientboundSetCameraPacket(player));
+        player.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) user.gameMode()));
+        var level = FabricMappingCompat.serverLevel(player);
+        long fixedDayTime = (long) user.worldTime();
+        player.connection.send(new ClientboundSetTimePacket(
+            -50L,
+            fixedDayTime,
+            true
+        ));
+
+        final Map<Integer, Object> tracked = entities.row(player.getUUID());
+        int[] trackedIds = tracked.keySet().stream().mapToInt(Integer::intValue).toArray();
+        IntArrayList toRemove = new IntArrayList(trackedIds.length + 1);
+        toRemove.add(DISPLAY_ENTITY_ID);
+        for (int id : trackedIds) {
+            toRemove.add(id);
+        }
+        if (!toRemove.isEmpty()) {
+            player.connection.send(new ClientboundRemoveEntitiesPacket(toRemove));
+        }
+        for (Integer id : trackedIds) {
+            net.minecraft.world.entity.Entity entity = level.getEntity(id);
+            if (entity != null) {
+                entity.discard();
+            }
+        }
+        tracked.clear();
+
+        player.stopRiding();
+        player.setInvisible(false);
+        FabricMappingCompat.teleport(
+            player,
+            level,
+            user.position().x(),
+            user.position().y(),
+            user.position().z(),
+            (float) initialRotation.x(),
+            (float) initialRotation.y()
+        );
+
+        player.connection.send(new ClientboundSetTimePacket(
+            -50L,
+            fixedDayTime,
+            true
+        ));
+        player.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) user.gameMode()));
+        player.connection.send(new ClientboundSetCameraPacket(player));
+
+        sendColumnBlock(player, Blocks.AIR.defaultBlockState());
+
+        player.connection.send(new ClientboundRemoveMobEffectPacket(player.getId(), MobEffects.INVISIBILITY));
+
+        if (user instanceof UserImpl impl) {
+            impl.resendInv();
+        }
+    }
+
+    @Override
+    public void gameTime(@NotNull SunscreenUser<?> user) {
+        ServerPlayer player = fabricPlayer(user);
+        player.connection.send(new ClientboundSetTimePacket(
+            -50L,
+            (long) user.worldTime(),
+            true
+        ));
+    }
+
+    @Override
+    public void bundleDelimiter(@NotNull SunscreenUser<?> user) {
+        // Vanilla uses StreamCodec.unit(one delimiter instance); new ClientboundBundleDelimiterPacket() breaks encoding.
+    }
+
+    @Override
+    public void openEmptyAnvil(SunscreenUser<?> user) {
+        ServerPlayer player = fabricPlayer(user);
+        player.openMenu(new SimpleMenuProvider((containerId, playerInventory, ignored) -> {
+            AnvilMenu menu = new AnvilMenu(containerId, playerInventory);
+            ItemStack paper = Items.PAPER.getDefaultInstance();
+            paper.set(DataComponents.CUSTOM_MODEL_DATA, modelData("air"));
+            paper.set(DataComponents.CUSTOM_NAME, Component.empty());
+            menu.getSlot(0).set(paper);
+            return menu;
+        }, Component.empty()));
+    }
+
+    @Override
+    public void sendItems(@NotNull SunscreenUser<?> user) {
+        ServerPlayer player = fabricPlayer(user);
+        ItemStack stack = Items.TRIDENT.getDefaultInstance();
+        stack.set(DataComponents.CUSTOM_NAME, Component.empty());
+        stack.set(DataComponents.CUSTOM_MODEL_DATA, modelData("air"));
+        int syncId = player.inventoryMenu.containerId;
+        int stateId = player.inventoryMenu.incrementStateId();
+        NonNullList<ItemStack> slots = NonNullList.withSize(44, ItemStack.EMPTY);
+        for (int i = 0; i < 44; i++) {
+            slots.set(i, stack.copy());
+        }
+        player.connection.send(new ClientboundContainerSetSlotPacket(syncId, stateId, 45, stack.copy()));
+        player.connection.send(new ClientboundContainerSetContentPacket(syncId, stateId, slots, stack.copy()));
+    }
+
+    @Override
+    public void removeMaps(@NotNull SunscreenUser<?> user) {
+        ServerPlayer player = fabricPlayer(user);
+        Map<Integer, Object> row = entities.row(player.getUUID());
+        int[] ids = row.entrySet().stream()
+            .filter(e -> e.getValue() instanceof ItemFrame)
+            .mapToInt(Map.Entry::getKey)
+            .toArray();
+        for (int id : ids) {
+            row.remove(id);
+            net.minecraft.world.entity.Entity entity = FabricMappingCompat.serverLevel(player).getEntity(id);
+            if (entity != null) {
+                entity.discard();
+            }
+        }
+    }
+
+    private static BlockPos columnPos(ServerPlayer player) {
+        return player.blockPosition().above();
+    }
+
+    private static void sendTime(ServerPlayer player, long gameTime, long dayTime) {
+        player.connection.send(new ClientboundSetTimePacket(gameTime, dayTime, true));
+    }
+
+    /**
+     * 1.21+ only exposes {@link ClientboundSetCameraPacket#ClientboundSetCameraPacket(net.minecraft.world.entity.Entity)}.
+     * Fake spectate targets (tab list + spawn packet only) have no server entity, so we decode the same wire shape the codec uses.
+     */
+    private static ClientboundSetCameraPacket cameraPacketFor(ServerPlayer player, int entityId) {
+        if (entityId == player.getId()) {
+            return new ClientboundSetCameraPacket(player);
+        }
+        net.minecraft.world.entity.Entity entity = FabricMappingCompat.serverLevel(player).getEntity(entityId);
+        if (entity != null) {
+            return new ClientboundSetCameraPacket(entity);
+        }
+        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+        buf.writeVarInt(entityId);
+        return ClientboundSetCameraPacket.STREAM_CODEC.decode(buf);
+    }
+
+    private static ClientboundPlayerInfoUpdatePacket playerInfoAddPacket(ServerPlayer player, ClientboundPlayerInfoUpdatePacket.Entry entry) {
+        var packet = new ClientboundPlayerInfoUpdatePacket(
+                ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER,
+                player
+        );
+        packet.entries = List.of(entry);
+        return packet;
+    }
+
+    private static void fakeArmorStandHit(ServerPlayer player) {
+        for (ArmorStand stand : FabricMappingCompat.serverLevel(player).getEntitiesOfClass(ArmorStand.class, player.getBoundingBox().inflate(10.0))) {
+            player.connection.send(new ClientboundEntityEventPacket(stand, (byte) 32));
+        }
+    }
+
+    private static void sendColumnBlock(ServerPlayer player, net.minecraft.world.level.block.state.BlockState state) {
+        player.connection.send(new ClientboundBlockUpdatePacket(columnPos(player), state));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void copyProfileProperties(GameProfile target, GameProfile source) {
+        Object targetProps = FabricMappingCompat.gameProfileProperties(target);
+        Object sourceProps = FabricMappingCompat.gameProfileProperties(source);
+        if (targetProps instanceof Map targetMap && sourceProps instanceof Map sourceMap) {
+            targetMap.putAll(sourceMap);
+        }
+    }
+
+    private CustomModelData modelData(String key) {
+        int id = switch (key) {
+            case "air" -> 9000;
+            case "cursor_default" -> 1;
+            case "cursor_text" -> 2;
+            case "cursor_move" -> 3;
+            case "cursor_resize_vertical" -> 4;
+            case "cursor_resize_horizontal" -> 5;
+            case "cursor_magnify" -> 6;
+            case "cursor_await" -> 7;
+            case "cursor_click" -> 8;
+            default -> 1;
+        };
+        return FabricMappingCompat.customModelData(id);
+    }
+
+    private ServerPlayer fabricPlayer(SunscreenUser<?> user) {
+        if (user instanceof UserImpl impl) {
+            return impl.player();
+        }
+        throw new IllegalStateException("Expected Fabric user implementation");
+    }
+
+    @Override
+    public void clientToServer(@NotNull ByteBuffer logical) {
+        ByteBuffer buf = logical.slice();
+        byte[] bytes = new byte[buf.remaining()];
+        buf.get(bytes);
+        ByteBuffer packet = NativeUiChunkBinary.encode(bytes.length, 0, 1, bytes);
+        sender.accept(new NativeUiChunkC2SPayload(packet.array()));
+    }
+
+    @Override
+    public void serverToClient(@NotNull SunscreenUser<?> user, @NotNull ByteBuffer payloadPacket) {
+        ByteBuffer copy = payloadPacket.slice();
+        byte[] out = new byte[copy.remaining()];
+        copy.get(out);
+        ServerPlayNetworking.send(fabricPlayer(user), new NativeUiChunkS2CPayload(out));
+    }
+
+    public static void setSender(Consumer<NativeUiChunkC2SPayload> s) {
+        sender = s;
+    }
+
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/user/UserImpl.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/user/UserImpl.java
@@ -1,0 +1,158 @@
+package me.combimagnetron.sunscreen.fabric.user;
+
+import me.combimagnetron.passport.internal.entity.Entity;
+import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
+import me.combimagnetron.passport.internal.network.Connection;
+import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.neo.ActiveMenu;
+import me.combimagnetron.sunscreen.neo.MenuTemplate;
+import me.combimagnetron.sunscreen.neo.protocol.type.Location;
+import me.combimagnetron.sunscreen.neo.render.ScreenInfo;
+import me.combimagnetron.sunscreen.neo.render.Viewport;
+import me.combimagnetron.sunscreen.fabric.SunscreenFabricMod;
+import me.combimagnetron.sunscreen.fabric.SunscreenLibraryFabric;
+import me.combimagnetron.sunscreen.fabric.protocol.FabricMappingCompat;
+import me.combimagnetron.sunscreen.neo.session.Session;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Collections;
+import java.util.UUID;
+
+public final class UserImpl implements SunscreenUser<Audience> {
+    private final ServerPlayer player;
+    private final Audience audience;
+    private final ScreenInfo screenInfo = new ScreenInfo(new Viewport(Vec2i.of(800, 450), Vec2i.of(800, 450), Vec2i.zero()));
+    private volatile boolean nativeUi;
+
+    public static UserImpl of(ServerPlayer player) {
+        return new UserImpl(player);
+    }
+
+    /**
+     * Returns the Sunscreen user for this player when the Fabric library is initialised, creating
+     * the {@link UserImpl} if the play-join handler has not run yet (e.g. very early custom payloads).
+     */
+    public static @Nullable UserImpl tryOf(ServerPlayer player) {
+        SunscreenLibraryFabric library = SunscreenFabricMod.library();
+        if (library == null) {
+            return null;
+        }
+        return library.userManager().ensureUser(player);
+    }
+
+    private UserImpl(ServerPlayer player) {
+        this.player = player;
+        this.audience = new PlayerAudience(player);
+    }
+
+    public ServerPlayer player() {
+        return player;
+    }
+
+    @Override
+    public @NotNull ScreenInfo screenInfo() {
+        return screenInfo;
+    }
+
+    @Override
+    public @Nullable Session session() {
+        return SunscreenLibrary.library().sessionHandler().session(this);
+    }
+
+    @Override
+    public @NotNull Session open(@NotNull MenuTemplate template) {
+        final Session current = session();
+        if (current != null) {
+            current.menu().close();
+        }
+        new ActiveMenu(template, this, template.identifier());
+        final Session created = session();
+        if (created == null) {
+            throw new IllegalStateException("Failed to create menu session for " + uniqueIdentifier());
+        }
+        return created;
+    }
+
+    @Override
+    public @NotNull Location eyeLocation() {
+        return new Location(player.getX(), player.getEyeY(), player.getZ());
+    }
+
+    @Override
+    public Audience platformSpecificPlayer() {
+        return audience;
+    }
+
+    @Override
+    public String name() {
+        return player.getName().getString();
+    }
+
+    @Override
+    public UUID uniqueIdentifier() {
+        return player.getUUID();
+    }
+
+    @Override
+    public Connection connection() {
+        return null;
+    }
+
+    @Override
+    public Vector3d position() {
+        return Vector3d.vec3(player.getX(), player.getY(), player.getZ());
+    }
+
+    @Override
+    public void show(Entity entity) {
+        // Fabric protocol implementation sends packets/entities directly where needed.
+    }
+
+    @Override
+    public int entityId() {
+        return player.getId();
+    }
+
+    @Override
+    public Vector3d rotation() {
+        return Vector3d.vec3(player.getYRot(), player.getXRot(), 0);
+    }
+
+    @Override
+    public int gameMode() {
+        return player.gameMode.getGameModeForPlayer().getId();
+    }
+
+    @Override
+    public float worldTime() {
+        return 0f;
+    }
+
+    @Override
+    public void resendInv() {
+        player.containerMenu.broadcastChanges();
+    }
+
+    @Override
+    public boolean useNativeUi() {
+        return nativeUi;
+    }
+
+    @Override
+    public void setNativeUi(boolean enabled) {
+        this.nativeUi = enabled;
+    }
+
+    public record PlayerAudience(ServerPlayer player) implements ForwardingAudience {
+        @Override
+        public Iterable<? extends Audience> audiences() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/user/UserManager.java
+++ b/fabric/src/main/java/me/combimagnetron/sunscreen/fabric/user/UserManager.java
@@ -1,0 +1,88 @@
+package me.combimagnetron.sunscreen.fabric.user;
+
+import me.combimagnetron.passport.internal.network.ByteBuffer;
+import me.combimagnetron.passport.user.UserHandler;
+import me.combimagnetron.sunscreen.neo.session.Session;
+import me.combimagnetron.sunscreen.user.SunscreenUser;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.kyori.adventure.audience.Audience;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class UserManager implements UserHandler<Audience, SunscreenUser<Audience>> {
+    private final Map<UUID, UserImpl> userMap = new ConcurrentHashMap<>();
+
+    public UserManager() {
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+            ensureUser(handler.getPlayer());
+        });
+
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
+            ServerPlayer player = handler.getPlayer();
+            UserImpl user = userMap.remove(player.getUUID());
+            if (user == null) {
+                return;
+            }
+            user.setNativeUi(false);
+            Session session = user.session();
+            if (session != null) {
+                session.menu().close();
+            }
+        });
+    }
+
+    /**
+     * Returns the Sunscreen user for this player, creating the {@link UserImpl} if missing.
+     * Used so early packets (e.g. native UI handshake right after play) never see a null user before JOIN runs.
+     */
+    public @NotNull UserImpl ensureUser(@NotNull ServerPlayer player) {
+        return userMap.computeIfAbsent(player.getUUID(), id -> UserImpl.of(player));
+    }
+
+    public UserImpl user(ServerPlayer player) {
+        return userMap.get(player.getUUID());
+    }
+
+    public UserImpl userRaw(UUID uuid) {
+        return userMap.get(uuid);
+    }
+
+    @Override
+    public SunscreenUser<Audience> user(Audience audience) {
+        if (audience instanceof UserImpl.PlayerAudience playerAudience) {
+            return userMap.get(playerAudience.player().getUUID());
+        }
+        return null;
+    }
+
+    @Override
+    public Optional<SunscreenUser<Audience>> user(UUID uuid) {
+        return Optional.ofNullable(userMap.get(uuid));
+    }
+
+    @Override
+    public Optional<SunscreenUser<Audience>> user(String s) {
+        return userMap.values().stream().filter(user -> user.name().equalsIgnoreCase(s)).findFirst().map(user -> user);
+    }
+
+    @Override
+    public Collection<SunscreenUser<Audience>> users() {
+        return java.util.Collections.unmodifiableCollection(new java.util.ArrayList<>(userMap.values()));
+    }
+
+    @Override
+    public Collection<SunscreenUser<Audience>> global() {
+        return users();
+    }
+
+    @Override
+    public SunscreenUser<Audience> deserialize(ByteBuffer byteBuffer) {
+        return null;
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "id": "sunscreen",
+  "version": "${version}",
+  "name": "Sunscreen",
+  "description": "Create UIs like never seen before, all from within the game!",
+  "authors": [
+    "Combimagnetron"
+  ],
+  "contact": {
+    "homepage": "https://combimagnetron.me"
+  },
+  "license": "MIT",
+  "accessWidener": "sunscreen.accesswidener",
+  "environment": "*",
+  "entrypoints": {
+    "client": [
+      "me.combimagnetron.sunscreen.fabric.client.SunscreenFabricClientMod"
+    ],
+    "main": [
+      "me.combimagnetron.sunscreen.fabric.SunscreenFabricMod"
+    ]
+  },
+  "mixins": [
+    {
+      "config": "sunscreen.mixins.json",
+      "environment": "server"
+    }
+  ],
+  "depends": {
+    "fabricloader": ">=0.18.3",
+    "minecraft": ">=${minecraftVersion}",
+    "fabric-api": ">=${fabricModules}"
+  }
+}

--- a/fabric/src/main/resources/sunscreen.accesswidener
+++ b/fabric/src/main/resources/sunscreen.accesswidener
@@ -1,0 +1,6 @@
+accessWidener v2 named
+
+accessible field com/mojang/blaze3d/platform/NativeImage pixels J
+accessible method com/mojang/blaze3d/platform/NativeImage <init> (Lcom/mojang/blaze3d/platform/NativeImage$Format;IIZJ)V
+accessible field net/minecraft/network/protocol/game/ClientboundPlayerInfoUpdatePacket entries Ljava/util/List;
+mutable field net/minecraft/network/protocol/game/ClientboundPlayerInfoUpdatePacket entries Ljava/util/List;

--- a/fabric/src/main/resources/sunscreen.mixins.json
+++ b/fabric/src/main/resources/sunscreen.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "me.combimagnetron.sunscreen.fabric.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "ServerCommonPacketListenerImplMixin",
+    "ServerGamePacketListenerImplMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,10 +5,14 @@ packetevents = "2.11.2"
 jackson = "2.20.1"
 creative = "1.11.8"
 paper = "1.21.11-R0.1-SNAPSHOT"
+minecraft = "1.21.1"
+loom = "1.16-SNAPSHOT"
+fabric-loader = "0.18.3"
 
 [libraries]
 passport = { group = "me.combimagnetron", name = "Passport", version = "1.0-SNAPSHOT" }
 paper = { group = "io.papermc.paper", name = "paper-api", version.ref = "paper" }
+fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabric-loader" }
 # --- Minecraft ---
 # Lamp Command Framework
 lamp-common = { group = "io.github.revxrsal", name = "lamp.common", version.ref = "lamp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/minestom/build.gradle.kts
+++ b/minestom/build.gradle.kts
@@ -25,3 +25,9 @@ application {
 tasks.processResources {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}

--- a/minestom/src/main/java/me/combimagnetron/sunscreen/MinestomPlatformProtocolIntermediate.java
+++ b/minestom/src/main/java/me/combimagnetron/sunscreen/MinestomPlatformProtocolIntermediate.java
@@ -34,11 +34,17 @@ import net.minestom.server.sound.SoundEvent;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.ByteBuffer;
 import java.util.*;
 
 public class MinestomPlatformProtocolIntermediate implements PlatformProtocolIntermediate<ItemStack> {
     private final static AttributeModifier ATTRIBUTE_MODIFIER = new AttributeModifier(Key.key("sunscreen:attribute"), 0, AttributeOperation.ADD_MULTIPLIED_BASE);
     private final Table<UUID, Integer, Object> entities = HashBasedTable.create();
+
+    @Override
+    public void serverToClient(@NotNull SunscreenUser<?> user, @NotNull ByteBuffer payloadPacket) {
+        // Minestom native UI transport is not implemented in this module.
+    }
 
     @Override
     public EntityReference<?> spawnAndRideHorse(@NotNull SunscreenUser<?> user, @NotNull Location location) {

--- a/minestom/src/main/java/me/combimagnetron/sunscreen/PacketListener.java
+++ b/minestom/src/main/java/me/combimagnetron/sunscreen/PacketListener.java
@@ -146,6 +146,9 @@ public class PacketListener {
     private void handleRotation(float yaw, float pitch, SunscreenUser<?> user) {
         final Session session = user.session();
         if (session == null) return;
+        if (session.menu().useNativeClientPath()) {
+            return;
+        }
         final InputHandler inputHandler = session.menu().inputHandler();
         inputHandler.peek(MouseInputContext.class, old -> old.withPosition(RotationHelper.convert(yaw, pitch, user.screenInfo())), user);
     }

--- a/minestom/src/main/java/me/combimagnetron/sunscreen/SunscreenLibraryMinestom.java
+++ b/minestom/src/main/java/me/combimagnetron/sunscreen/SunscreenLibraryMinestom.java
@@ -11,6 +11,7 @@ import me.combimagnetron.sunscreen.user.UserManager;
 import net.kyori.adventure.audience.Audience;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
+import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -18,13 +19,13 @@ import org.slf4j.Logger;
 import java.io.InputStream;
 import java.nio.file.Path;
 
-public class SunscreenLibraryMinestom implements SunscreenLibrary<Object, Player> {
+public class SunscreenLibraryMinestom implements SunscreenLibrary<Object, Player, ItemStack> {
     private final MinestomPlatformProtocolIntermediate protocolIntermediate = new MinestomPlatformProtocolIntermediate();
     private final SessionHandler sessionHandler = new SessionHandler();
     private final UserManager userManager = new UserManager();
 
     protected SunscreenLibraryMinestom() {
-        Holder.INSTANCE = this;
+        SunscreenLibrary.Holder.INSTANCE = this;
     }
 
 
@@ -90,7 +91,7 @@ public class SunscreenLibraryMinestom implements SunscreenLibrary<Object, Player
     }
 
     @Override
-    public @NotNull PlatformProtocolIntermediate intermediate() {
+    public @NotNull PlatformProtocolIntermediate<ItemStack> intermediate() {
         return protocolIntermediate;
     }
 

--- a/minestom/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
+++ b/minestom/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
@@ -115,4 +115,9 @@ public class UserImpl implements SunscreenUser<Player> {
         player.getInventory().update();
     }
 
+    @Override
+    public boolean useNativeUi() {
+        return false;
+    }
+
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.fabricmc.net/")
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }
@@ -20,3 +21,4 @@ include("api")
 include("spigot")
 include("minestom")
 include("common")
+include("fabric")

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/SunscreenPlugin.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/SunscreenPlugin.java
@@ -5,6 +5,7 @@ import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder
 import me.combimagnetron.passport.Passport;
 import me.combimagnetron.passport.util.data.Identifier;
 import me.combimagnetron.sunscreen.command.SunscreenCommand;
+import me.combimagnetron.sunscreen.nativeui.SpigotNativeUiNetworking;
 import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.font.AtlasFont;
 import me.combimagnetron.sunscreen.neo.registry.Registries;
 import me.combimagnetron.sunscreen.placeholder.PapiPlaceholderProvider;
@@ -30,6 +31,7 @@ public class SunscreenPlugin extends JavaPlugin implements Listener {
     private Lamp<BukkitCommandActor> lamp;
     private SunscreenLibrary<SunscreenPlugin, Player, ItemStack> library;
     private UserManager userManager;
+    private SpigotNativeUiNetworking nativeUiNetworking;
 
 
     @Override
@@ -49,6 +51,8 @@ public class SunscreenPlugin extends JavaPlugin implements Listener {
         Passport.Holder.INSTANCE = library.passport();
         this.getDataFolder().mkdirs();
         this.userManager = new UserManager(this);
+        this.nativeUiNetworking = new SpigotNativeUiNetworking(this);
+        this.nativeUiNetworking.registerChannels();
         folders();
         commands();
         //menus();
@@ -122,6 +126,9 @@ public class SunscreenPlugin extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
+        if (nativeUiNetworking != null) {
+            nativeUiNetworking.unregisterChannels();
+        }
         PacketEvents.getAPI().terminate();
     }
 

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/nativeui/SpigotNativeUiNetworking.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/nativeui/SpigotNativeUiNetworking.java
@@ -1,0 +1,47 @@
+package me.combimagnetron.sunscreen.nativeui;
+
+import me.combimagnetron.sunscreen.SunscreenPlugin;
+import me.combimagnetron.sunscreen.user.UserImpl;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+public final class SpigotNativeUiNetworking implements PluginMessageListener {
+    private final SunscreenPlugin plugin;
+
+    public SpigotNativeUiNetworking(@NotNull SunscreenPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void registerChannels() {
+        plugin.getServer().getMessenger().registerIncomingPluginChannel(plugin, NativeUi.CHANNEL, this);
+        plugin.getServer().getMessenger().registerOutgoingPluginChannel(plugin, NativeUi.CHANNEL);
+    }
+
+    public void unregisterChannels() {
+        plugin.getServer().getMessenger().unregisterIncomingPluginChannel(plugin, NativeUi.CHANNEL, this);
+        plugin.getServer().getMessenger().unregisterOutgoingPluginChannel(plugin, NativeUi.CHANNEL);
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte @NotNull [] message) {
+        if (!NativeUi.CHANNEL.equals(channel)) {
+            return;
+        }
+        try {
+            Optional<?> userOpt = me.combimagnetron.sunscreen.SunscreenLibrary.library().users().user(player.getUniqueId());
+            if (userOpt.isEmpty()) {
+                return;
+            }
+            Object u = userOpt.get();
+            if (!(u instanceof UserImpl user)) {
+                return;
+            }
+            NativeUi.receiveServerC2SPacket(user, message);
+        } catch (RuntimeException ex) {
+            plugin.getComponentLogger().warn("Invalid native UI chunk from {}", player.getName(), ex);
+        }
+    }
+}

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/ProtocolListener.java
@@ -199,6 +199,9 @@ public class ProtocolListener implements PacketListener {
         event.setCancelled(true);
         final Session session = user.session();
         if (session == null) return;
+        if (session.menu().useNativeClientPath()) {
+            return;
+        }
         final InputHandler inputHandler = session.menu().inputHandler();
         float rawYaw = wrapperPlayClientPlayerRotation.getYaw();
         float yaw = ((rawYaw + 360/2f) % 360 + 360) % 360 - 360/2f;

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/SpigotPlatformProtocolIntermediate.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/protocol/SpigotPlatformProtocolIntermediate.java
@@ -37,8 +37,11 @@ import me.combimagnetron.passport.internal.entity.impl.passive.horse.Horse;
 import me.combimagnetron.passport.internal.entity.impl.tile.ItemFrame;
 import me.combimagnetron.passport.internal.entity.metadata.type.Vector3d;
 import me.combimagnetron.passport.internal.network.Connection;
+import me.combimagnetron.passport.util.data.Identifier;
 import me.combimagnetron.passport.user.User;
 import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.SunscreenLibrary;
+import me.combimagnetron.sunscreen.SunscreenPlugin;
 import me.combimagnetron.sunscreen.neo.graphic.Item;
 import me.combimagnetron.sunscreen.neo.input.context.TextInputContext;
 import me.combimagnetron.sunscreen.neo.protocol.PlatformProtocolIntermediate;
@@ -51,6 +54,7 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.ByteBuffer;
 import java.util.*;
 
 public class SpigotPlatformProtocolIntermediate implements PlatformProtocolIntermediate<org.bukkit.inventory.ItemStack> {
@@ -345,6 +349,25 @@ public class SpigotPlatformProtocolIntermediate implements PlatformProtocolInter
                                         component(ComponentTypes.EQUIPPABLE,
                                                 new ItemEquippable(EquipmentSlot.BODY, Sounds.ITEM_ARMOR_EQUIP_GENERIC, new ResourceLocation("sunscreen", texturePath), null, null, false, false, false)).build())));
 
+    }
+
+    private static @NotNull SunscreenPlugin plugin() {
+        Object plugin = SunscreenLibrary.library().plugin();
+        if (plugin instanceof SunscreenPlugin spigotPlugin) {
+            return spigotPlugin;
+        }
+        throw new IllegalStateException("Expected SunscreenPlugin for Spigot native UI transport");
+    }
+
+    @Override
+    public void serverToClient(@NotNull SunscreenUser<?> user, @NotNull ByteBuffer payloadPacket) {
+        if (!(user.platformSpecificPlayer() instanceof Player player)) {
+            return;
+        }
+        ByteBuffer copy = payloadPacket.slice();
+        byte[] out = new byte[copy.remaining()];
+        copy.get(out);
+        player.sendPluginMessage(plugin(), me.combimagnetron.sunscreen.nativeui.NativeUi.CHANNEL, out);
     }
 
 }

--- a/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
+++ b/spigot/src/main/java/me/combimagnetron/sunscreen/user/UserImpl.java
@@ -32,6 +32,7 @@ public class UserImpl implements SunscreenUser<Player> {
     private final ClientVersion version;
     private final float fov = 70;
     private final ScreenInfo screenInfo = new ScreenInfo(new Viewport(Vec2i.of(800, 450), Vec2i.of(800, 450), Vec2i.zero()));
+    private volatile boolean nativeUi;
 
     public static UserImpl of(Player player) {
         return new UserImpl(player);
@@ -134,6 +135,16 @@ public class UserImpl implements SunscreenUser<Player> {
     @Override
     public void resendInv() {
         player.updateInventory();
+    }
+
+    @Override
+    public boolean useNativeUi() {
+        return nativeUi;
+    }
+
+    @Override
+    public void setNativeUi(boolean enabled) {
+        this.nativeUi = enabled;
     }
 
     public static class PacketEventsConnectionImpl<T> implements Connection {


### PR DESCRIPTION
Adds a native client side screen used to render Sunscreen UIs allowing for greater UI performance and compatibility with Iris shaders and other problematic mods.

<img width="1423" height="783" alt="java_NyU2WPoRt1" src="https://github.com/user-attachments/assets/aa2e7f34-694f-4345-bebe-4ba561c87ec1" />

When the client has this mod installed and logs into any server it sends a single hello plugin message. Sunscreen acknowledges this hello and swaps the display mode from server side maps + shaders to client side via plugin messages.

In this implementation the server still owns rendering the UI but pushes rendered frames through the following optimized codec:
- Server breaks rendering into 128^2 tiles and only send the ones which change through
- If a tile only has <= 10 variations, the server tells the client to cache the current variation (via xxhash) and future renders of this tile variation only require 8 bytes.
- The entire payload is compressed via a global LZ4 frame stream. Renders of  100kb+ drop to ~8kb
- This system provides best case rendering in <100b and worst case of <32kb per call
> For a detailed read of the codec used to render over the wire see MenuRasterWireCodec.

The screen simply captures mouse and keyboard interactions and sends everything through to the server.

The mod has been tested and works on both 1.21.1 and 1.21.11.

WIP: Minestom plugin message handlers
WIP: Fabric server side support for vanilla clients