### PR TITLE
Add element positions relative to element size

### DIFF
--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/ActiveMenu.java
@@ -25,6 +25,7 @@ import me.combimagnetron.sunscreen.neo.protocol.type.Location;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderPipeline;
 import me.combimagnetron.sunscreen.neo.render.engine.pipeline.RenderThreadPoolHandler;
 import me.combimagnetron.sunscreen.neo.session.Session;
+import me.combimagnetron.sunscreen.neo.theme.ModernTheme;
 import me.combimagnetron.sunscreen.user.SunscreenUser;
 import me.combimagnetron.sunscreen.util.IdentifierHolder;
 import me.combimagnetron.sunscreen.util.Scheduler;
@@ -33,6 +34,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import me.combimagnetron.sunscreen.util.helper.ElementSizeSeeder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +79,7 @@ public class ActiveMenu implements IdentifierHolder {
         template.build(menuRoot);
         loadComponents();
         intermediate.gameTime(user);
+        ElementSizeSeeder.seedMenuTree(menuRoot.elementLikes(), loadedTheme());
         for (ElementLike<?> elementLike : menuRoot.elementLikes()) {
             if (elementLike instanceof GenericInteractableModernElement<?, ?, ?> interactableModernElement) {
                 interactableModernElement.inputHandler(inputHandler);
@@ -92,6 +99,14 @@ public class ActiveMenu implements IdentifierHolder {
         }
     }
 
+    private @Nullable ModernTheme loadedTheme() {
+        return loadedComponents.values().stream()
+            .filter(ModernTheme.class::isInstance)
+            .map(ModernTheme.class::cast)
+            .findFirst()
+            .orElse(null);
+    }
+
     public @NotNull MenuRoot root() {
         return menuRoot;
     }
@@ -109,6 +124,7 @@ public class ActiveMenu implements IdentifierHolder {
     }
 
     public @NotNull ActiveMenu add(@NotNull ElementLike<?> @NotNull... elementLikes) {
+        ElementSizeSeeder.seedMenuTree(Arrays.asList(elementLikes), loadedTheme());
         renderPipeline.submit(elementLikes);
         return this;
     }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/Elements.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/Elements.java
@@ -71,7 +71,7 @@ public interface Elements {
     }
 
     static @NotNull ButtonElement button(@NotNull Identifier identifier, @NotNull Text text) {
-        return new ButtonElement(identifier, text, Vec2i.zero());
+        return new ButtonElement(identifier, text);
     }
 
     static @NotNull ButtonElement button(@NotNull Identifier identifier, @NotNull Text text, @NotNull Vec2i position) {

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/ModernElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/ModernElement.java
@@ -1,9 +1,17 @@
 package me.combimagnetron.sunscreen.neo.element;
 
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.graphic.GraphicLike;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.Renderable;
+import org.jetbrains.annotations.Nullable;
 
 public interface ModernElement<E extends ModernElement<E, G>, G extends GraphicLike<G>> extends ElementLike<E>, Renderable<Size, G> {
 
+    /**
+     * Natural pixel size from content (bitmap, text, shape, etc.), or {@code null} if unknown without theme / explicit {@link Size}.
+     */
+    default @Nullable Vec2i intrinsicSize() {
+        return null;
+    }
 }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ButtonElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ButtonElement.java
@@ -35,6 +35,7 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
     private ElementPhase phase = ElementPhase.DEFAULT;
     private int click = 0;
     private Vec2i textPosition = Vec2i.zero();
+    private boolean autoCenterText = false;
     private Canvas canvas;
 
     public ButtonElement(@NotNull Identifier identifier) {
@@ -46,6 +47,12 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
         text = label;
         if (textPosition != null)
             this.textPosition = textPosition;
+    }
+
+    public ButtonElement(@NotNull Identifier identifier, @Nullable Text label) {
+        super(identifier);
+        this.text = label;
+        this.autoCenterText = true;
     }
 
     @Override
@@ -66,6 +73,12 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
 
     public @NotNull ButtonElement textPosition(@Nullable Vec2i position) {
         this.textPosition = position;
+        this.autoCenterText = false;
+        return this;
+    }
+
+    public @NotNull ButtonElement autoCenterText(boolean autoCenterText) {
+        this.autoCenterText = autoCenterText;
         return this;
     }
 
@@ -142,7 +155,15 @@ public class ButtonElement extends GenericInteractableModernElement<ButtonElemen
             Text buttonText = text;
             if (phase == ElementPhase.DISABLED) buttonText.color(TextColor.color(Color.of(93, 93, 93)));
             else buttonText.color(TextColor.color(Color.of(255, 255, 255)));
-            button.place(buttonText.render(size, context), textPosition);
+            Canvas renderedText = buttonText.render(size, context).trim();
+            Vec2i placePosition = textPosition;
+            if (autoCenterText) {
+                placePosition = Vec2i.of(
+                    (sizeVec.x() - renderedText.size().x()) / 2,
+                    (sizeVec.y() - renderedText.size().y()) / 2
+                );
+            }
+            button.place(renderedText, placePosition);
         }
         // button.modifier(GraphicModifiers.mask(Shape.rectangle(Vec2i.of(20, 20)),
         // ModifierContext.of()));

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ImageElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ImageElement.java
@@ -3,6 +3,7 @@ package me.combimagnetron.sunscreen.neo.element.impl;
 import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.GraphicLike;
 import me.combimagnetron.passport.util.data.Identifier;
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.engine.context.RenderContext;
 import org.jetbrains.annotations.NotNull;
@@ -15,6 +16,11 @@ public class ImageElement<G extends GraphicLike<G>> extends GenericModernElement
     public ImageElement(@NotNull Identifier identifier, @NotNull G graphicLike) {
         super(identifier);
         this.graphic = graphicLike;
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return graphic.bufferedColorSpace().size();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/LabelElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/LabelElement.java
@@ -7,7 +7,6 @@ import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.passport.util.data.Identifier;
 import me.combimagnetron.sunscreen.neo.graphic.text.Text;
-import me.combimagnetron.sunscreen.neo.graphic.text.style.impl.font.FontProperties;
 import me.combimagnetron.sunscreen.neo.property.Size;
 import me.combimagnetron.sunscreen.neo.render.engine.context.RenderContext;
 import me.combimagnetron.sunscreen.util.helper.PropertyHelper;
@@ -33,6 +32,14 @@ public class LabelElement extends GenericModernElement<LabelElement, Canvas> {
         MutableState<Text> componentMutableState = (MutableState<Text>) componentState;
         componentMutableState.observe((old, current) -> {
         });
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return text.value()
+            .render(Size.fixed(Vec2i.of(4096, 1024)), null)
+            .trim()
+            .size();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ShapeElement.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/element/impl/ShapeElement.java
@@ -1,6 +1,7 @@
 package me.combimagnetron.sunscreen.neo.element.impl;
 
 import me.combimagnetron.passport.util.data.Identifier;
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.element.GenericModernElement;
 import me.combimagnetron.sunscreen.neo.graphic.Canvas;
 import me.combimagnetron.sunscreen.neo.graphic.color.Color;
@@ -22,6 +23,15 @@ public class ShapeElement extends GenericModernElement<ShapeElement, Canvas> {
 
     public ShapeElement(@NotNull Identifier identifier, @NotNull Shape shape) {
         this(identifier, shape, Color.of(255, 255, 255));
+    }
+
+    public @NotNull Shape shape() {
+        return shape;
+    }
+
+    @Override
+    public @Nullable Vec2i intrinsicSize() {
+        return shape.squareSize();
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/NineSlice.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/graphic/NineSlice.java
@@ -44,6 +44,10 @@ public final class NineSlice {
         cutPieces();
     }
 
+    public @NotNull Canvas sourceCanvas() {
+        return canvas;
+    }
+
     private void cutPieces() {
         Vec2i canvasSize = canvas.size();
         Vec2i position = Vec2i.zero();

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/layout/Layout.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/layout/Layout.java
@@ -181,7 +181,7 @@ public interface Layout<E extends ModernElement<E, Canvas>> extends ElementConta
         private void handleElement(@NotNull ModernElement<?, Canvas> elementLike) {
             Vec2i vecPos = PropertyHelper.vectorOrThrow(elementLike.position(), Vec2i.class);
             Vec2i layoutVecPos = PropertyHelper.vectorOrThrow(position(), Vec2i.class);
-            elementLike.position(Position.fixed(vecPos.add(layoutVecPos)));
+            elementLike.position(Position.fixed(vecPos.add(layoutVecPos)).target(elementLike.position().target()));
             if (!(elementLike instanceof GenericInteractableModernElement<?,?,?> interactableModernElement)) return;
             interactableModernElement.inputHandler(handler);
         }

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Position.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/property/Position.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Position> implements EditorProperty<Vec2i, Position, SelectorInputContext.ValueInnerContext> {
@@ -16,6 +17,33 @@ public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Po
     private static final Position ZERO = Position.fixed(Vec2i.zero());
 
     private final Map<RelativeMeasure.Axis2d, RelativeMeasure.RelativeBuilder<Size>> axisMap = new LinkedHashMap<>();
+    private Target target = Target.TOP_LEFT;
+
+    /**
+     * Anchor on the element box: position value is the point named by the constant; {@link #resolve(Vec2i)} returns top-left
+     * by subtracting {@link #offset(Vec2i)} from that point.
+     */
+    public enum Target {
+        TOP_LEFT(s -> Vec2i.zero()),
+        TOP_CENTER(s -> Vec2i.of(s.x() / 2, 0)),
+        TOP_RIGHT(s -> Vec2i.of(s.x(), 0)),
+        LEFT_CENTER(s -> Vec2i.of(0, s.y() / 2)),
+        CENTER(s -> Vec2i.of(s.x() / 2, s.y() / 2)),
+        RIGHT_CENTER(s -> Vec2i.of(s.x(), s.y() / 2)),
+        BOTTOM_LEFT(s -> Vec2i.of(0, s.y())),
+        BOTTOM_CENTER(s -> Vec2i.of(s.x() / 2, s.y())),
+        BOTTOM_RIGHT(s -> Vec2i.of(s.x(), s.y()));
+
+        private final Function<Vec2i, Vec2i> anchorToTopLeftOffset;
+
+        Target(@NotNull Function<Vec2i, Vec2i> anchorToTopLeftOffset) {
+            this.anchorToTopLeftOffset = anchorToTopLeftOffset;
+        }
+
+        public @NotNull Vec2i offset(@NotNull Vec2i elementSize) {
+            return anchorToTopLeftOffset.apply(elementSize);
+        }
+    }
 
     public static Position nil() {
         return ZERO;
@@ -44,6 +72,20 @@ public final class Position extends RelativeMeasure.Vec2iRelativeMeasureGroup<Po
 
     public static @NotNull Position supplied(@NotNull Supplier<Vec2i> supplier) {
         return new Position(supplier);
+    }
+
+    public @NotNull Position target(@NotNull Target target) {
+        this.target = target;
+        return this;
+    }
+
+    public @NotNull Target target() {
+        return target;
+    }
+
+    public @NotNull Position resolve(@NotNull Vec2i size) {
+        Vec2i value = value();
+        return new Position(value.sub(target.offset(size)));
     }
 
     @Override

--- a/api/src/main/java/me/combimagnetron/sunscreen/neo/property/PropertyContainer.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/neo/property/PropertyContainer.java
@@ -1,6 +1,8 @@
 package me.combimagnetron.sunscreen.neo.property;
 
+import me.combimagnetron.passport.util.math.Vec2i;
 import me.combimagnetron.sunscreen.neo.theme.decorator.Target;
+import me.combimagnetron.sunscreen.util.helper.PropertyHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,7 +36,11 @@ public interface PropertyContainer<R> {
     }
 
     default @NotNull Position position() {
-        return propOrThrow(Position.class);
+        var pos = propOrThrow(Position.class);
+        if (pos.target() != Position.Target.TOP_LEFT) {
+            return pos.resolve(PropertyHelper.vectorOrThrow(size(), Vec2i.class));
+        }
+        return pos;
     }
 
     default @NotNull Margin margin() {

--- a/api/src/main/java/me/combimagnetron/sunscreen/util/helper/ElementSizeSeeder.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/util/helper/ElementSizeSeeder.java
@@ -1,0 +1,137 @@
+package me.combimagnetron.sunscreen.util.helper;
+
+import me.combimagnetron.passport.util.math.Vec2i;
+import me.combimagnetron.sunscreen.neo.element.ElementContainer;
+import me.combimagnetron.sunscreen.neo.element.ElementLike;
+import me.combimagnetron.sunscreen.neo.element.GenericInteractableModernElement;
+import me.combimagnetron.sunscreen.neo.element.ModernElement;
+import me.combimagnetron.sunscreen.neo.graphic.Canvas;
+import me.combimagnetron.sunscreen.neo.graphic.NineSlice;
+import me.combimagnetron.sunscreen.neo.property.Decorator;
+import me.combimagnetron.sunscreen.neo.property.Size;
+import me.combimagnetron.sunscreen.neo.theme.ModernTheme;
+import me.combimagnetron.sunscreen.neo.theme.decorator.ThemeDecorator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * Fills missing {@link Size} from element content ({@link ModernElement#intrinsicSize()}) and, when a
+ * {@link ModernTheme} is present, from themed nine-slice <strong>source</strong> canvases.
+ * <p>
+ * Call only via {@link #seedMenuTree(Collection, ModernTheme)} after the menu tree is fully built (or for roots
+ * passed to {@link me.combimagnetron.sunscreen.neo.ActiveMenu#add}).
+ */
+public final class ElementSizeSeeder {
+
+    private ElementSizeSeeder() {}
+
+    /**
+     * Runs intrinsic sizing for every node under {@code roots}, then a theme pass for any size still missing.
+     */
+    public static void seedMenuTree(@NotNull Collection<ElementLike<?>> roots, @Nullable ModernTheme theme) {
+        for (ElementLike<?> root : roots) {
+            seedRecursive(root);
+        }
+        seedFromTheme(roots, theme);
+    }
+
+    private static void seedRecursive(@NotNull ElementLike<?> elementLike) {
+        if (elementLike instanceof ElementContainer<?> container) {
+            for (ModernElement<?, Canvas> child : container.children()) {
+                seedRecursive(child);
+            }
+        }
+        if (elementLike instanceof ModernElement<?, ?> modern) {
+            seedElement(modern);
+        }
+    }
+
+    private static void seedFromTheme(@NotNull Collection<ElementLike<?>> roots, @Nullable ModernTheme theme) {
+        if (theme == null) return;
+        for (ElementLike<?> root : roots) {
+            seedFromThemeRecursive(root, theme);
+        }
+    }
+
+    private static void seedFromThemeRecursive(@NotNull ElementLike<?> elementLike, @NotNull ModernTheme theme) {
+        if (elementLike instanceof ElementContainer<?> container) {
+            for (ModernElement<?, Canvas> child : container.children()) {
+                seedFromThemeRecursive(child, theme);
+            }
+        }
+        if (elementLike instanceof ModernElement<?, ?> modern) {
+            seedElementFromTheme(modern, theme);
+        }
+    }
+
+    private static void seedElementFromTheme(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        if (!needsIntrinsicSeed(element.property(Size.class))) return;
+        Vec2i fromTheme = sizeFromResolvedThemeDecorator(element, theme);
+        if (fromTheme != null) element.size(Size.fixed(fromTheme));
+    }
+
+    private static void seedElement(@NotNull ModernElement<?, ?> element) {
+        Size sizeProp = element.property(Size.class);
+        if (!needsIntrinsicSeed(sizeProp)) return;
+        Vec2i intrinsic = element.intrinsicSize();
+        if (intrinsic == null) return;
+        element.size(Size.fixed(intrinsic));
+    }
+
+    /**
+     * @return true if we should assign a fixed intrinsic size before layout / render.
+     */
+    private static boolean needsIntrinsicSeed(@Nullable Size sizeProp) {
+        if (sizeProp == null) return true;
+        if (sizeProp instanceof Size.Fit) return true;
+        if (sizeProp.value() != null) return false;
+        // Unresolved relative size: resolved from viewport in the render pipeline.
+        return sizeProp.axisBuilderMap().isEmpty();
+    }
+
+    /**
+     * Mirrors {@code RenderContext.decorator} target resolution, then reads intrinsic size from nine-slice source art.
+     */
+    private static @Nullable Vec2i sizeFromResolvedThemeDecorator(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        ThemeDecorator decorator = resolveThemeDecorator(element, theme);
+        return sizeFromThemeDecorator(decorator);
+    }
+
+    private static @Nullable ThemeDecorator resolveThemeDecorator(@NotNull ModernElement<?, ?> element, @NotNull ModernTheme theme) {
+        Decorator<?> dec = element.property(Decorator.class);
+        if (dec == null || dec.target().target().equals(element.getClass())) {
+            for (ThemeDecorator candidate : theme.decorators()) {
+                if (candidate.target().target().equals(element.getClass())) return candidate;
+            }
+            return null;
+        }
+        return theme.find(dec.target());
+    }
+
+    private static @Nullable Vec2i sizeFromThemeDecorator(@Nullable ThemeDecorator decorator) {
+        if (decorator == null) return null;
+        if (decorator instanceof ThemeDecorator.StateNineSliceThemeDecorator stated) {
+            return firstNineSliceSourceSize(stated);
+        }
+        if (decorator instanceof ThemeDecorator.NineSliceThemeDecorator simple) {
+            return simple.nineSlice().sourceCanvas().size();
+        }
+        return null;
+    }
+
+    private static @Nullable Vec2i firstNineSliceSourceSize(@NotNull ThemeDecorator.StateNineSliceThemeDecorator stated) {
+        NineSlice slice = stated.nineSlices().get(GenericInteractableModernElement.ElementPhase.DEFAULT);
+        if (slice == null) {
+            for (NineSlice candidate : stated.nineSlices().values()) {
+                if (candidate != null) {
+                    slice = candidate;
+                    break;
+                }
+            }
+        }
+        return slice == null ? null : slice.sourceCanvas().size();
+    }
+
+}

--- a/api/src/main/java/me/combimagnetron/sunscreen/util/helper/HoverHelper.java
+++ b/api/src/main/java/me/combimagnetron/sunscreen/util/helper/HoverHelper.java
@@ -12,7 +12,7 @@ public class HoverHelper {
     private HoverHelper() {}
 
     public static <E extends ElementLike<E>> boolean in(@NotNull ElementLike<E> elementLike, @NotNull Vec2i cursor) {
-        final Position position = elementLike.propOrThrow(Position.class);
+        final Position position = elementLike.position();
         final Size size = elementLike.propOrThrow(Size.class);
         Vec2i vecPosition = position.value();
         Vec2i vecSize = size.value();
@@ -29,7 +29,7 @@ public class HoverHelper {
     public static <E extends ElementLike<E>> boolean in(@NotNull ElementLike<E> elementLike, @NotNull Viewport viewport) {
         Vec2i vecPosition = viewport.position();
         Vec2i vecSize = viewport.currentView();
-        Vec2i elementPosition = elementLike.propOrThrow(Position.class).value();
+        Vec2i elementPosition = elementLike.position().value();
         boolean xCheck = (elementPosition.x() >= vecPosition.x() && elementPosition.x() <= vecPosition.x() + vecSize.x());
         boolean yCheck = (elementPosition.y() >= vecPosition.y() && elementPosition.y() <= vecPosition.y() + vecSize.y());
         return xCheck && yCheck;


### PR DESCRIPTION
In the current Sunscreen API, every element is positioned with its top left as the anchor. This makes use cases like centering or justifying challenging, especially when the content is dynamic.

This PR aims to solve this by adding the following dynamic positioning targets for elements:
- TOP_LEFT
- TOP_CENTER
- TOP_RIGHT
- LEFT_CENTER
- CENTER
- RIGHT_CENTER
- BOTTOM_LEFT
- BOTTOM_CENTER
- BOTTOM_RIGHT

Positions can define targets with chaining: `Position.fixed(...).target(...)`. Targets also support relative() and fit() positions.

This PR also allows labelled buttons to use the CENTER target for the label by omitting the `textPosition` argument in the ButtonElement constructor. For example `new ButtonElement(Identifier, label)` will render the `label` centered within the button.

This PR required us to know the size of elements before rendering them which was not possible before. To do this we add `intrinsicSize()` to allow us to accurately infer the size of an element when it is not explicitly defined by the user.